### PR TITLE
WorkerHandler survives config changes

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/WorkerHandlerTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/WorkerHandlerTest.java
@@ -1,0 +1,24 @@
+package com.otaliastudios.cameraview;
+
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class WorkerHandlerTest {
+
+    @Test
+    public void testCache() {
+        WorkerHandler w1 = WorkerHandler.get("handler1");
+        WorkerHandler w1a = WorkerHandler.get("handler1");
+        WorkerHandler w2 = WorkerHandler.get("handler2");
+        assertTrue(w1 == w1a);
+        assertFalse(w1 == w2);
+    }
+}

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -35,7 +35,7 @@ abstract class CameraController implements Preview.SurfaceCallback {
         mCameraCallbacks = callback;
         mPreview = preview;
         mPreview.setSurfaceCallback(this);
-        mHandler = new WorkerHandler("CameraViewController");
+        mHandler = WorkerHandler.get("CameraViewController");
     }
 
     //region Start&Stop

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -117,7 +117,7 @@ public class CameraView extends FrameLayout {
         mPreviewImpl = instantiatePreview(context, this);
         mCameraController = instantiateCameraController(mCameraCallbacks, mPreviewImpl);
         mUiHandler = new Handler(Looper.getMainLooper());
-        mWorkerHandler = new WorkerHandler("CameraViewWorker");
+        mWorkerHandler = WorkerHandler.get("CameraViewWorker");
 
         // Views
         mGridLinesLayout = new GridLinesLayout(context);

--- a/cameraview/src/main/utils/com/otaliastudios/cameraview/WorkerHandler.java
+++ b/cameraview/src/main/utils/com/otaliastudios/cameraview/WorkerHandler.java
@@ -3,12 +3,33 @@ package com.otaliastudios.cameraview;
 import android.os.Handler;
 import android.os.HandlerThread;
 
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Class holding a background handler.
- * Using setDaemon right now but a better approach would be to have
- * start() and stop() callbacks here. TODO
+ * We want them to survive configuration changes if there's still job to do.
  */
 class WorkerHandler {
+
+    private static ConcurrentHashMap<String, WeakReference<WorkerHandler>> sCache = new ConcurrentHashMap<>(4);
+
+    public static WorkerHandler get(String name) {
+        if (sCache.containsKey(name)) {
+            WorkerHandler cached = sCache.get(name).get();
+            if (cached != null) {
+                HandlerThread thread = cached.mThread;
+                if (thread.isAlive() && !thread.isInterrupted()) {
+                    return cached;
+                }
+            }
+            sCache.remove(name);
+        }
+        WorkerHandler handler = new WorkerHandler(name);
+        sCache.put(name, new WeakReference<>(handler));
+        return handler;
+    }
 
     private HandlerThread mThread;
     private Handler mHandler;

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -13,18 +13,18 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:name="com.otaliastudios.cameraview.demo.MainActivity"
-            android:theme="@style/Theme.MainActivity">
+            android:name=".MainActivity"
+            android:theme="@style/Theme.MainActivity"
+            android:configChanges="orientation|screenLayout|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <activity
-            android:name="com.otaliastudios.cameraview.demo.PicturePreviewActivity" />
+        <activity android:name=".PicturePreviewActivity" />
 
-        <activity android:name="com.otaliastudios.cameraview.demo.VideoPreviewActivity"/>
+        <activity android:name=".VideoPreviewActivity"/>
 
     </application>
 


### PR DESCRIPTION
Have handlers survive config changes so start() and stop() calls are streamlined. Fixes #28 .