### PR TITLE
Use SurfaceViewPreview when hardware acceleration is off

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -159,7 +159,10 @@ public class CameraView extends FrameLayout {
 
 
     protected Preview instantiatePreview(Context context, ViewGroup container) {
-        return new TextureViewPreview(context, container, null);
+        // TextureView is not supported without hardware acceleration.
+        return isHardwareAccelerated() ?
+                new TextureViewPreview(context, container, null) :
+                new SurfaceViewPreview(context, container, null);
     }
 
 

--- a/cameraview/src/main/views/com/otaliastudios/cameraview/SurfaceViewPreview.java
+++ b/cameraview/src/main/views/com/otaliastudios/cameraview/SurfaceViewPreview.java
@@ -8,7 +8,7 @@ import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
 
-// This is not used.
+// Fallback preview when hardware acceleration is off.
 class SurfaceViewPreview extends Preview<SurfaceView, SurfaceHolder> {
 
 


### PR DESCRIPTION
TextureView won't work when hardware acceleration is off for some reason.
Fallback to our other preview implementation.