### PR TITLE
Dont require AUDIO permission if audio is OFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,15 +445,15 @@ Take also a look at public methods in `CameraUtils`, `CameraOptions`, `ExtraProp
 `CameraView` needs two permissions:
 
 - `android.permission.CAMERA` : required for capturing pictures and videos
-- `android.permission.RECORD_AUDIO` : required for capturing videos
+- `android.permission.RECORD_AUDIO` : required for capturing videos with `Audio.ON` (the default)
 
-You can handle permissions yourself and then call `CameraView.start()` once they are acquired. If they are not, `CameraView` will request permissions to the user based on the `sessionType` that was set. In that case, you can restart the camera if you have a successful response from `onRequestPermissionResults()`.
+You can handle permissions yourself and then call `CameraView.start()` once they are acquired. If they are not, `CameraView` will request permissions to the user based on whether they are needed. In that case, you can restart the camera if you have a successful response from `onRequestPermissionResults()`.
 
 ## Manifest file
 
 The library manifest file is not strict and only asks for camera permissions. This means that:
 
-- If you wish to record videos, you should also add `android.permission.RECORD_AUDIO` to required permissions
+- If you wish to record videos with `Audio.ON` (the default), you should also add `android.permission.RECORD_AUDIO` to required permissions
 
 ```xml
 <uses-permission android:name="android.permission.RECORD_AUDIO"/>

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
@@ -55,7 +55,7 @@ public class CameraViewTest extends BaseTest {
                     }
 
                     @Override
-                    protected boolean checkPermissions(SessionType sessionType) {
+                    protected boolean checkPermissions(SessionType sessionType, Audio audio) {
                         return hasPermissions;
                     }
                 };

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -494,7 +494,7 @@ public class CameraView extends FrameLayout {
             return;
         }
 
-        if (checkPermissions(getSessionType())) {
+        if (checkPermissions(getSessionType(), getAudio())) {
             mIsStarted = true;
             // Update display orientation for current CameraController
             mOrientationHelper.enable(getContext());


### PR DESCRIPTION
Setting audio to `Audio.OFF` will let you use the library without audio permission.