### PR TITLE
Enable IntegrationTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # https://github.com/andstatus/andstatus/blob/master/.travis.yml
-
+#
 language: android
 
 branches:

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -34,14 +34,11 @@ import static org.mockito.Mockito.spy;
 
 
 /**
- * These tests work great on real devices, and are the only way to test actual CameraController
+ * These tests are the only way to test actual CameraController
  * implementation - we really need to open the camera device.
- * Unfortunately they fail unreliably on emulated devices, due to some bug with the
- * emulated camera controller. Waiting for it to be fixed.
  */
 @RunWith(AndroidJUnit4.class)
 @MediumTest
-@Ignore
 public class IntegrationTest extends BaseTest {
 
     @Rule


### PR DESCRIPTION
These do actually work great on real devices, but are not reliable on emulators due to some errors from the emulator camera bindings, that might appear some time and leave the camera resource in a bad state:

```
E/EmulatedCamera_Device(   65): stopThread: Thread control FDs are not opened
E/EmulatedCamera_Device(   65): stopWorkerThread: Unable to stop worker thread
E/EmulatedCamera_Device(   65): stopDeliveringFrames: startWorkerThread failed
```

```
E/EmulatedCamera_Device(   65): startWorkerThread: Unable to start worker thread
E/EmulatedCamera_Device(   65): startDeliveringFrames: startWorkerThread failed
```

Waiting for some fix / workaround.