### PR TITLE
Add playSounds control

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ Most camera parameters can be controlled through XML attributes or linked method
     app:cameraVideoQuality="480p"
     app:cameraWhiteBalance="auto"
     app:cameraHdr="off"
-    app:cameraAudio="on"/>
+    app:cameraAudio="on"
+    app:cameraPlaySounds="true"/>
 ```
 
 |XML Attribute|Method|Values|Default Value|
@@ -311,6 +312,7 @@ Most camera parameters can be controlled through XML attributes or linked method
 |[`cameraWhiteBalance`](#camerawhitebalance)|`setWhiteBalance()`|`auto` `incandescent` `fluorescent` `daylight` `cloudy`|`auto`|
 |[`cameraHdr`](#camerahdr)|`setHdr()`|`off` `on`|`off`|
 |[`cameraAudio`](#cameraaudio)|`setAudio()`|`off` `on`|`on`|
+|[`cameraPlaySounds`](#cameraplaysounds)|`setPlaySounds()`|`true` `false`|`true`|
 
 #### cameraSessionType
 
@@ -408,11 +410,24 @@ cameraView.setHdr(Hdr.ON);
 
 #### cameraAudio
 
-Turns on or off audio stream.
+Turns on or off audio stream while recording videos.
 
 ```java
 cameraView.setAudio(Audio.OFF);
 cameraView.setAudio(Audio.ON);
+```
+
+#### cameraPlaySounds
+
+Controls whether we should play platform-provided sounds during certain events (shutter click, focus completed).
+Please note that:
+
+- on API < 16, this flag is always set to `false`
+- the Camera1 engine will always play shutter sounds regardless of this flag
+
+```java
+cameraView.setPlaySounds(true);
+cameraView.setPlaySounds(false);
 ```
 
 ## Other APIs

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
@@ -93,6 +93,7 @@ public class CameraViewTest extends BaseTest {
         // Self managed
         assertEquals(cameraView.getExposureCorrection(), 0f, 0f);
         assertEquals(cameraView.getZoom(), 0f, 0f);
+        assertEquals(cameraView.getPlaySounds(), CameraView.DEFAULT_PLAY_SOUNDS);
         assertEquals(cameraView.getCropOutput(), CameraView.DEFAULT_CROP_OUTPUT);
         assertEquals(cameraView.getJpegQuality(), CameraView.DEFAULT_JPEG_QUALITY);
         assertEquals(cameraView.getGestureAction(Gesture.TAP), GestureAction.DEFAULT_TAP);
@@ -447,6 +448,14 @@ public class CameraViewTest extends BaseTest {
         assertEquals(cameraView.getJpegQuality(), 10);
         cameraView.setJpegQuality(100);
         assertEquals(cameraView.getJpegQuality(), 100);
+    }
+
+    @Test
+    public void testSetPlaySounds() {
+        cameraView.setPlaySounds(true);
+        assertEquals(cameraView.getPlaySounds(), true);
+        cameraView.setPlaySounds(false);
+        assertEquals(cameraView.getPlaySounds(), false);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -96,6 +96,8 @@
             <enum name="on" value="1" />
         </attr>
 
+        <attr name="cameraPlaySounds" format="boolean" />
+
         <!-- deprecated attr name="cameraZoomMode" format="enum">
             <enum name="off" value="0" />
             <enum name="pinch" value="1" />


### PR DESCRIPTION
Lets you choose whether to play sound effects. 
Camera1 will always play the shutter sound no matter this flag. But Camera2 won't have this issue.

Fixes #34 