### PR TITLE
Fixes #90 Remove UncaughtExceptionHandler from CameraController in stopImmediately

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -144,9 +144,9 @@ abstract class CameraController implements CameraPreview.SurfaceCallback {
             // Don't check, try stop again.
             LOG.i("Stop immediately. State was:", ss());
             mState = STATE_STOPPING;
-            onStop();
             // Prevent leaking CameraController.
             mHandler.getThread().setUncaughtExceptionHandler(null);
+            onStop();
             mState = STATE_STOPPED;
             LOG.i("Stop immediately. Stopped. State is:", ss());
         } catch (Exception e) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -145,6 +145,8 @@ abstract class CameraController implements CameraPreview.SurfaceCallback {
             LOG.i("Stop immediately. State was:", ss());
             mState = STATE_STOPPING;
             onStop();
+            // Prevent leaking CameraController.
+            mHandler.getThread().setUncaughtExceptionHandler(null);
             mState = STATE_STOPPED;
             LOG.i("Stop immediately. Stopped. State is:", ss());
         } catch (Exception e) {


### PR DESCRIPTION
I verified this fixes the memory leak because I can no longer trigger it with Leakcanary in my app.

One thing I'm a bit concerned about is that `stopImmeditely()` is currently only called from `CameraView.destroy()`, so this codes works when the user wants to destroy the camera permanently, but if a user tries to `start()` the camera again, the `UncaughtExceptionHandler` won't be restored.

Should we be restoring / setting the `UncaughtExceptionHandler` in `start()`?

 