### PR TITLE
Reduced memory usage to avoid any OOM.

### DIFF
--- a/cameraview/src/main/utils/com/otaliastudios/cameraview/CropHelper.java
+++ b/cameraview/src/main/utils/com/otaliastudios/cameraview/CropHelper.java
@@ -27,6 +27,7 @@ class CropHelper {
         image.recycle();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         crop.compress(Bitmap.CompressFormat.JPEG, jpegCompression, out);
+        crop.recycle();
         return out.toByteArray();
     }
 


### PR DESCRIPTION
# Implements
https://github.com/natario1/CameraView/issues/91

# Description
Reduced memory usage to avoid any OOM.

## Before
Library could lead to OOM due to the huge amount of memory allocated by the bitmap.
![no_improvement](https://user-images.githubusercontent.com/14893090/32302743-ec53ffde-bf29-11e7-8758-9be52cac3028.gif)
(Java memory increases up to 60 MB, sometimes up to 100 MB!)

## After
Memory usage reduced and released the bitmap memory allocated.
![improvement](https://user-images.githubusercontent.com/14893090/32302792-29ae0f00-bf2a-11e7-93f4-96bb742638e3.gif)
(Java memory increases from 17 MB to 25 MB only)

## Reviewers
See reviewer section.