### PR TITLE
Make CameraView thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See below for a [list of what was done](#roadmap) and [licensing info](#contribu
   - Automatically detected orientation tags
   - Plug in location tags with `setLocation()` API
 - `CameraUtils` to help with Bitmaps and orientations
+- Error handling
 - **Lightweight**, no dependencies, just support `ExifInterface`
 - Works down to API level 15
 
@@ -168,6 +169,16 @@ camera.addCameraListener(new CameraListener() {
      */
     @Override
     public void onCameraClosed() {}
+
+    /**
+     * Notifies about an error during the camera setup or configuration.
+     * At the moment, errors that are passed here are unrecoverable. When this is called,
+     * the camera has been released and is presumably showing a black preview.
+     *
+     * This is the right moment to show an error dialog to the user.
+     */
+    @Override
+    public void onCameraError(CameraException error) {}
 
     /**
      * Notifies that a picture previously captured with capturePicture()
@@ -605,6 +616,7 @@ all the code was changed.
 - *Better threading, start() in worker thread and callbacks in UI*
 - *Frame processor support*
 - *inject external loggers*
+- *error handling*
 
 These are still things that need to be done, off the top of my head:
 
@@ -612,7 +624,6 @@ These are still things that need to be done, off the top of my head:
 - [ ] add a `setPreferredAspectRatio` API to choose the capture size. Preview size will adapt, and then, if let free, the CameraView will adapt as well
 - [ ] animate grid lines similar to stock camera app
 - [ ] add onRequestPermissionResults for easy permission callback
-- [ ] better error handling, maybe with a onError(e) method in the public listener, or have each public method return a boolean
 - [ ] decent code coverage
 
 # Contributing and licenses

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraCallbacksTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraCallbacksTest.java
@@ -225,6 +225,8 @@ public class CameraCallbacksTest extends BaseTest {
         verify(listener, times(1)).onOrientationChanged(anyInt());
     }
 
+    // TODO: test onShutter, here or elsewhere
+
 
     @Test
     public void testProcessJpeg() {

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraCallbacksTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraCallbacksTest.java
@@ -73,8 +73,7 @@ public class CameraCallbacksTest extends BaseTest {
                 camera.instantiatePreview();
                 camera.addCameraListener(listener);
                 camera.addFrameProcessor(processor);
-                task = new Task<>();
-                task.listen();
+                task = new Task<>(true);
             }
         });
     }
@@ -266,8 +265,7 @@ public class CameraCallbacksTest extends BaseTest {
 
     private int[] testProcessImage(boolean jpeg, boolean crop, int[] viewDim, int[] imageDim) {
         // End our task when onPictureTaken is called. Take note of the result.
-        final Task<byte[]> jpegTask = new Task<>();
-        jpegTask.listen();
+        final Task<byte[]> jpegTask = new Task<>(true);
         doAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraUtilsTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraUtilsTest.java
@@ -48,8 +48,7 @@ public class CameraUtilsTest extends BaseTest {
         source.compress(Bitmap.CompressFormat.PNG, 100, os);
         final byte[] data = os.toByteArray();
 
-        final Task<Bitmap> decode = new Task<>();
-        decode.listen();
+        final Task<Bitmap> decode = new Task<>(true);
         final CameraUtils.BitmapCallback callback = new CameraUtils.BitmapCallback() {
             @Override
             public void onBitmapReady(Bitmap bitmap) {

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(AndroidJUnit4.class)
 @MediumTest
-public class CameraCallbacksTest extends BaseTest {
+public class CameraViewCallbacksTest extends BaseTest {
 
     private CameraView camera;
     private CameraListener listener;
@@ -226,6 +226,15 @@ public class CameraCallbacksTest extends BaseTest {
 
     // TODO: test onShutter, here or elsewhere
 
+    @Test
+    public void testCameraError() {
+        CameraException error = new CameraException(new RuntimeException("Error"));
+        completeTask().when(listener).onCameraError(error);
+
+        camera.mCameraCallbacks.dispatchError(error);
+        assertNotNull(task.await(200));
+        verify(listener, times(1)).onCameraError(error);
+    }
 
     @Test
     public void testProcessJpeg() {

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
@@ -92,10 +92,10 @@ public class CameraViewTest extends BaseTest {
         assertEquals(cameraView.getAudio(), Audio.DEFAULT);
         assertEquals(cameraView.getVideoQuality(), VideoQuality.DEFAULT);
         assertEquals(cameraView.getLocation(), null);
-
-        // Self managed
         assertEquals(cameraView.getExposureCorrection(), 0f, 0f);
         assertEquals(cameraView.getZoom(), 0f, 0f);
+
+        // Self managed
         assertEquals(cameraView.getPlaySounds(), CameraView.DEFAULT_PLAY_SOUNDS);
         assertEquals(cameraView.getCropOutput(), CameraView.DEFAULT_CROP_OUTPUT);
         assertEquals(cameraView.getJpegQuality(), CameraView.DEFAULT_JPEG_QUALITY);

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
  */
 @RunWith(AndroidJUnit4.class)
 @MediumTest
-// @Ignore
+@Ignore
 public class IntegrationTest extends BaseTest {
 
     @Rule

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
@@ -40,15 +40,15 @@ public class MockCameraController extends CameraController {
     }
 
     @Override
-    boolean setZoom(float zoom) {
+    void setZoom(float zoom, PointF[] points, boolean notify) {
+        mZoomValue = zoom;
         mZoomChanged = true;
-        return true;
     }
 
     @Override
-    boolean setExposureCorrection(float EVvalue) {
+    void setExposureCorrection(float EVvalue, float[] bounds, PointF[] points, boolean notify) {
+        mExposureCorrectionValue = EVvalue;
         mExposureCorrectionChanged = true;
-        return true;
     }
 
     @Override
@@ -92,24 +92,20 @@ public class MockCameraController extends CameraController {
     }
 
     @Override
-    boolean capturePicture() {
+    void capturePicture() {
         mPictureCaptured = true;
-        return true;
     }
 
     @Override
-    boolean captureSnapshot() {
-        return true;
+    void captureSnapshot() {
     }
 
     @Override
-    boolean startVideo(@NonNull File file) {
-        return true;
+    void startVideo(@NonNull File file) {
     }
 
     @Override
-    boolean endVideo() {
-        return true;
+    void endVideo() {
     }
 
     @Override
@@ -120,23 +116,19 @@ public class MockCameraController extends CameraController {
 
 
     @Override
-    boolean startAutoFocus(@Nullable Gesture gesture, PointF point) {
+    void startAutoFocus(@Nullable Gesture gesture, PointF point) {
         mFocusStarted = true;
-        return true;
     }
 
     @Override
     public void onSurfaceChanged() {
-
     }
 
     @Override
     public void onSurfaceAvailable() {
-
     }
 
     @Override
     public void onBufferAvailable(byte[] buffer) {
-
     }
 }

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
@@ -32,11 +32,11 @@ public class MockCameraController extends CameraController {
     }
 
     @Override
-    void onStart() throws Exception {
+    void onStart() {
     }
 
     @Override
-    void onStop() throws Exception {
+    void onStop() {
     }
 
     @Override

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/PreviewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/PreviewTest.java
@@ -31,8 +31,7 @@ public abstract class PreviewTest extends BaseTest {
 
     @Before
     public void setUp() {
-        availability = new Task<>();
-        availability.listen();
+        availability = new Task<>(true);
 
         ui(new Runnable() {
             @Override

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/WorkerHandlerTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/WorkerHandlerTest.java
@@ -24,8 +24,7 @@ public class WorkerHandlerTest extends BaseTest {
 
     @Test
     public void testStaticRun() {
-        final Task<Boolean> task = new Task<>();
-        task.listen();
+        final Task<Boolean> task = new Task<>(true);
         Runnable action = new Runnable() {
             @Override
             public void run() {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
@@ -37,12 +37,12 @@ class Camera2 extends CameraController {
     }
 
     @Override
-    void onStart() throws Exception {
+    void onStart() {
 
     }
 
     @Override
-    void onStop() throws Exception {
+    void onStop() {
 
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
@@ -57,13 +57,13 @@ class Camera2 extends CameraController {
     }
 
     @Override
-    boolean setZoom(float zoom) {
-        return false;
+    void setZoom(float zoom, PointF[] points, boolean notify) {
+
     }
 
     @Override
-    boolean setExposureCorrection(float EVvalue) {
-        return false;
+    void setExposureCorrection(float EVvalue, float[] bounds, PointF[] points, boolean notify) {
+
     }
 
     @Override
@@ -97,23 +97,23 @@ class Camera2 extends CameraController {
     }
 
     @Override
-    boolean capturePicture() {
-        return false;
+    void capturePicture() {
+
     }
 
     @Override
-    boolean captureSnapshot() {
-        return false;
+    void captureSnapshot() {
+
     }
 
     @Override
-    boolean startVideo(@NonNull File file) {
-        return false;
+    void startVideo(@NonNull File file) {
+
     }
 
     @Override
-    boolean endVideo() {
-        return false;
+    void endVideo() {
+
     }
 
     @Override
@@ -122,8 +122,8 @@ class Camera2 extends CameraController {
     }
 
     @Override
-    boolean startAutoFocus(@Nullable Gesture gesture, PointF point) {
-        return false;
+    void startAutoFocus(@Nullable Gesture gesture, PointF point) {
+
     }
 
     @Override

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -43,14 +43,18 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
 
     protected int mDisplayOffset;
     protected int mDeviceOrientation;
-
-    protected boolean mScheduledForStart = false;
-    protected boolean mScheduledForStop = false;
-    protected boolean mScheduledForRestart = false;
     protected int mState = STATE_STOPPED;
-    protected final Object mLock = new Object();
 
     protected WorkerHandler mHandler;
+
+    // Used for testing.
+    Task<Void> mZoomTask = new Task<>();
+    Task<Void> mExposureCorrectionTask = new Task<>();
+    Task<Void> mFlashTask = new Task<>();
+    Task<Void> mWhiteBalanceTask = new Task<>();
+    Task<Void> mHdrTask = new Task<>();
+    Task<Void> mLocationTask = new Task<>();
+    Task<Void> mVideoQualityTask = new Task<>();
 
     CameraController(CameraView.CameraCallbacks callback) {
         mCameraCallbacks = callback;
@@ -95,13 +99,11 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     // Starts the preview asynchronously.
     final void start() {
         LOG.i("Start:", "posting runnable. State:", ss());
-        mScheduledForStart = true;
         mHandler.post(new Runnable() {
             @Override
             public void run() {
                 try {
                     LOG.i("Start:", "executing. State:", ss());
-                    mScheduledForStart = false;
                     if (mState >= STATE_STARTING) return;
                     mState = STATE_STARTING;
                     LOG.i("Start:", "about to call onStart()", ss());
@@ -121,13 +123,11 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     // Stops the preview asynchronously.
     final void stop() {
         LOG.i("Stop:", "posting runnable. State:", ss());
-        mScheduledForStop = true;
         mHandler.post(new Runnable() {
             @Override
             public void run() {
                 try {
                     LOG.i("Stop:", "executing. State:", ss());
-                    mScheduledForStop = false;
                     if (mState <= STATE_STOPPED) return;
                     mState = STATE_STOPPING;
                     LOG.i("Stop:", "about to call onStop()");
@@ -165,13 +165,11 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     // Forces a restart.
     protected final void restart() {
         LOG.i("Restart:", "posting runnable");
-        mScheduledForRestart = true;
         mHandler.post(new Runnable() {
             @Override
             public void run() {
                 try {
                     LOG.i("Restart:", "executing. Needs stopping:", mState > STATE_STOPPED, ss());
-                    mScheduledForRestart = false;
                     // Don't stop if stopped.
                     if (mState > STATE_STOPPED) {
                         mState = STATE_STOPPING;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -30,6 +30,9 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     protected Location mLocation;
     protected Audio mAudio;
 
+    protected float mZoomValue;
+    protected float mExposureCorrectionValue;
+
     protected Size mCaptureSize;
     protected Size mPreviewSize;
     protected int mPreviewFormat;
@@ -45,6 +48,7 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     protected boolean mScheduledForStop = false;
     protected boolean mScheduledForRestart = false;
     protected int mState = STATE_STOPPED;
+    protected final Object mLock = new Object();
 
     protected WorkerHandler mHandler;
 
@@ -231,11 +235,11 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
     // Should restart the session if active.
     abstract void setFacing(Facing facing);
 
-    // If opened and supported, apply and return true.
-    abstract boolean setZoom(float zoom);
+    // If closed, no-op. If opened, check supported and apply.
+    abstract void setZoom(float zoom, PointF[] points, boolean notify);
 
-    // If opened and supported, apply and return true.
-    abstract boolean setExposureCorrection(float EVvalue);
+    // If closed, no-op. If opened, check supported and apply.
+    abstract void setExposureCorrection(float EVvalue, float[] bounds, PointF[] points, boolean notify);
 
     // If closed, keep. If opened, check supported and apply.
     abstract void setFlash(Flash flash);
@@ -260,17 +264,17 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
 
     //region APIs
 
-    abstract boolean capturePicture();
+    abstract void capturePicture();
 
-    abstract boolean captureSnapshot();
+    abstract void captureSnapshot();
 
-    abstract boolean startVideo(@NonNull File file);
+    abstract void startVideo(@NonNull File file);
 
-    abstract boolean endVideo();
+    abstract void endVideo();
 
     abstract boolean shouldFlipSizes(); // Wheter the Sizes should be flipped to match the view orientation.
 
-    abstract boolean startAutoFocus(@Nullable Gesture gesture, PointF point);
+    abstract void startAutoFocus(@Nullable Gesture gesture, PointF point);
 
     //endregion
 
@@ -316,6 +320,14 @@ abstract class CameraController implements CameraPreview.SurfaceCallback, FrameM
 
     final Audio getAudio() {
         return mAudio;
+    }
+
+    final float getZoomValue() {
+        return mZoomValue;
+    }
+
+    final float getExposureCorrectionValue() {
+        return mExposureCorrectionValue;
     }
 
     final Size getCaptureSize() {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraException.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraException.java
@@ -1,0 +1,12 @@
+package com.otaliastudios.cameraview;
+
+
+/**
+ * Holds an error with the camera configuration.
+ */
+public class CameraException extends RuntimeException {
+
+    CameraException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -78,8 +78,8 @@ public abstract class CameraListener {
 
     /**
      * Notifies that user interacted with the screen and started focus with a gesture,
-     * and the autofocus is trying to focus around that area.
-     * This can be used to draw things on screen.
+     * and the autofocus is trying to focus around that area. This can be used to draw things on screen.
+     * Can also be triggered by {@link CameraView#startAutoFocus(float, float)}.
      *
      * @param point coordinates with respect to CameraView.getWidth() and CameraView.getHeight()
      */
@@ -93,6 +93,7 @@ public abstract class CameraListener {
      * Notifies that a gesture focus event just ended, and the camera converged
      * to a new focus (and possibly exposure and white balance).
      * This might succeed or not.
+     * Can also be triggered by {@link CameraView#startAutoFocus(float, float)}.
      *
      * @param successful whether camera succeeded
      * @param point coordinates with respect to CameraView.getWidth() and CameraView.getHeight()

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -1,6 +1,7 @@
 package com.otaliastudios.cameraview;
 
 import android.graphics.PointF;
+import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 
 import java.io.File;
@@ -25,6 +26,25 @@ public abstract class CameraListener {
      */
     @UiThread
     public void onCameraClosed() {
+
+    }
+
+
+    /**
+     * Notifies about an error during the camera setup or configuration.
+     * At the moment, errors that are passed here are unrecoverable. When this is called,
+     * the camera has been released and is presumably showing a black preview.
+     *
+     * This is the right moment to show an error dialog to the user.
+     * You can try calling start() again, but that is not guaranteed to work - if it doesn't,
+     * this callback will be invoked again.
+     *
+     * In the future, more information will be passed through the {@link CameraException} instance.
+     *
+     * @param exception the error
+     */
+    @UiThread
+    public void onCameraError(@NonNull CameraException exception) {
 
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -52,8 +52,6 @@ public class CameraView extends FrameLayout {
     // Self managed parameters
     private int mJpegQuality;
     private boolean mCropOutput;
-    private float mZoomValue;
-    private float mExposureCorrectionValue;
     private boolean mPlaySounds;
     private HashMap<Gesture, GestureAction> mGestureMap = new HashMap<>(4);
 
@@ -448,7 +446,7 @@ public class CameraView extends FrameLayout {
     // Some gesture layout detected a gesture. It's not known at this moment:
     // (1) if it was mapped to some action (we check here)
     // (2) if it's supported by the camera (CameraController checks)
-    private boolean onGesture(GestureLayout source, @NonNull CameraOptions options) {
+    private void onGesture(GestureLayout source, @NonNull CameraOptions options) {
         Gesture gesture = source.getGestureType();
         GestureAction action = mGestureMap.get(gesture);
         PointF[] points = source.getPoints();
@@ -456,36 +454,29 @@ public class CameraView extends FrameLayout {
         switch (action) {
 
             case CAPTURE:
-                return mCameraController.capturePicture();
+                mCameraController.capturePicture();
+                break;
 
             case FOCUS:
             case FOCUS_WITH_MARKER:
-                return mCameraController.startAutoFocus(gesture, points[0]);
+                mCameraController.startAutoFocus(gesture, points[0]);
+                break;
 
             case ZOOM:
-                oldValue = mZoomValue;
+                oldValue = mCameraController.getZoomValue();
                 newValue = source.scaleValue(oldValue, 0, 1);
-                if (mCameraController.setZoom(newValue)) {
-                    mZoomValue = newValue;
-                    mCameraCallbacks.dispatchOnZoomChanged(newValue, points);
-                    return true;
-                }
+                mCameraController.setZoom(newValue, points, true);
                 break;
 
             case EXPOSURE_CORRECTION:
-                oldValue = mExposureCorrectionValue;
+                oldValue = mCameraController.getExposureCorrectionValue();
                 float minValue = options.getExposureCorrectionMinValue();
                 float maxValue = options.getExposureCorrectionMaxValue();
                 newValue = source.scaleValue(oldValue, minValue, maxValue);
                 float[] bounds = new float[]{minValue, maxValue};
-                if (mCameraController.setExposureCorrection(newValue)) {
-                    mExposureCorrectionValue = newValue;
-                    mCameraCallbacks.dispatchOnExposureCorrectionChanged(newValue, bounds, points);
-                    return true;
-                }
+                mCameraController.setExposureCorrection(newValue, bounds, points, true);
                 break;
         }
-        return false;
     }
 
     //endregion
@@ -640,9 +631,7 @@ public class CameraView extends FrameLayout {
             float max = options.getExposureCorrectionMaxValue();
             if (EVvalue < min) EVvalue = min;
             if (EVvalue > max) EVvalue = max;
-            if (mCameraController.setExposureCorrection(EVvalue)) {
-                mExposureCorrectionValue = EVvalue;
-            }
+            mCameraController.setExposureCorrection(EVvalue, null, null, false);
         }
     }
 
@@ -653,7 +642,7 @@ public class CameraView extends FrameLayout {
      * @return the current exposure correction value
      */
     public float getExposureCorrection() {
-        return mExposureCorrectionValue;
+        return mCameraController.getExposureCorrectionValue();
     }
 
 
@@ -670,9 +659,7 @@ public class CameraView extends FrameLayout {
     public void setZoom(float zoom) {
         if (zoom < 0) zoom = 0;
         if (zoom > 1) zoom = 1;
-        if (mCameraController.setZoom(zoom)) {
-            mZoomValue = zoom;
-        }
+        mCameraController.setZoom(zoom, null, false);
     }
 
 
@@ -681,7 +668,7 @@ public class CameraView extends FrameLayout {
      * @return the current zoom value
      */
     public float getZoom() {
-        return mZoomValue;
+        return mCameraController.getZoomValue();
     }
 
 
@@ -1146,9 +1133,7 @@ public class CameraView extends FrameLayout {
      * @see #captureSnapshot()
      */
     public void capturePicture() {
-        if (mCameraController.capturePicture() && mPlaySounds) {
-            // TODO: playSound on Camera2
-        }
+        mCameraController.capturePicture();
     }
 
 
@@ -1163,10 +1148,7 @@ public class CameraView extends FrameLayout {
      * @see #capturePicture()
      */
     public void captureSnapshot() {
-        if (mCameraController.captureSnapshot() && mPlaySounds) {
-            //noinspection all
-            playSound(MediaActionSound.SHUTTER_CLICK);
-        }
+        mCameraController.captureSnapshot();
     }
 
 
@@ -1193,15 +1175,14 @@ public class CameraView extends FrameLayout {
         if (file == null) {
             file = new File(getContext().getFilesDir(), "video.mp4");
         }
-        if (mCameraController.startVideo(file)) {
-            mUiHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                    mKeepScreenOn = getKeepScreenOn();
-                    if (!mKeepScreenOn) setKeepScreenOn(true);
-                }
-            });
-        }
+        mCameraController.startVideo(file);
+        mUiHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                mKeepScreenOn = getKeepScreenOn();
+                if (!mKeepScreenOn) setKeepScreenOn(true);
+            }
+        });
     }
 
 
@@ -1238,14 +1219,13 @@ public class CameraView extends FrameLayout {
      * This will fire {@link CameraListener#onVideoTaken(File)}.
      */
     public void stopCapturingVideo() {
-        if (mCameraController.endVideo()) {
-            mUiHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                    if (getKeepScreenOn() != mKeepScreenOn) setKeepScreenOn(mKeepScreenOn);
-                }
-            });
-        }
+        mCameraController.endVideo();
+        mUiHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (getKeepScreenOn() != mKeepScreenOn) setKeepScreenOn(mKeepScreenOn);
+            }
+        });
     }
 
 
@@ -1346,6 +1326,7 @@ public class CameraView extends FrameLayout {
         void dispatchOnCameraOpened(CameraOptions options);
         void dispatchOnCameraClosed();
         void onCameraPreviewSizeChanged();
+        void onShutter(boolean shouldPlaySound);
         void processImage(byte[] jpeg, boolean consistentWithView, boolean flipHorizontally);
         void processSnapshot(YuvImage image, boolean consistentWithView, boolean flipHorizontally);
         void dispatchOnVideoTaken(File file);
@@ -1408,6 +1389,13 @@ public class CameraView extends FrameLayout {
             });
         }
 
+        @Override
+        public void onShutter(boolean shouldPlaySound) {
+            if (shouldPlaySound && mPlaySounds) {
+                //noinspection all
+                playSound(MediaActionSound.SHUTTER_CLICK);
+            }
+        }
 
         /**
          * What would be great here is to ensure the EXIF tag in the jpeg is consistent with what we expect,

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -580,7 +580,7 @@ public class CameraView extends FrameLayout {
     public void destroy() {
         clearCameraListeners();
         clearFrameProcessors();
-        mCameraController.stopImmediately();
+        mCameraController.destroy();
     }
 
     //endregion
@@ -1335,6 +1335,7 @@ public class CameraView extends FrameLayout {
         void dispatchOnZoomChanged(final float newValue, final PointF[] fingers);
         void dispatchOnExposureCorrectionChanged(float newValue, float[] bounds, PointF[] fingers);
         void dispatchFrame(Frame frame);
+        void dispatchError(CameraException exception);
     }
 
     private class Callbacks implements CameraCallbacks {
@@ -1608,11 +1609,20 @@ public class CameraView extends FrameLayout {
                 });
             }
         }
+
+        @Override
+        public void dispatchError(final CameraException exception) {
+            mLogger.i("dispatchError", exception);
+            mUiHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    for (CameraListener listener : mListeners) {
+                        listener.onCameraError(exception);
+                    }
+                }
+            });
+        }
     }
-
-    //endregion
-
-    //region Deprecated
 
     //endregion
 }

--- a/cameraview/src/main/utils/com/otaliastudios/cameraview/Task.java
+++ b/cameraview/src/main/utils/com/otaliastudios/cameraview/Task.java
@@ -18,6 +18,10 @@ class Task<T> {
     Task() {
     }
 
+    Task(boolean startListening) {
+        if (startListening) listen();
+    }
+
     private boolean listening() {
         return mLatch != null;
     }

--- a/cameraview/src/test/java/com/otaliastudios/cameraview/CameraExceptionTest.java
+++ b/cameraview/src/test/java/com/otaliastudios/cameraview/CameraExceptionTest.java
@@ -1,0 +1,16 @@
+package com.otaliastudios.cameraview;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CameraExceptionTest {
+
+    @Test
+    public void testConstructor() {
+        RuntimeException cause = new RuntimeException("Error");
+        CameraException camera = new CameraException(cause);
+        assertEquals(cause, camera.getCause());
+    }
+}


### PR DESCRIPTION
- Make CameraView completely thread-safe
- All actions are posted to a single thread, like Camera1 docs suggest
- This should avoid any "used after release" error
- Add `CameraListener.onCameraError()` and `CameraException` for unrecoverable errors
- Fix some bugs with video recording and MediaRecorder not correctly setup or released

Fixes #77 
Fixes #61 