### PR TITLE
Max video file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ Other APIs not mentioned above are provided, and are well documented and comment
 |`getPreviewSize()`|Returns the size of the preview surface. If CameraView was not constrained in its layout phase (e.g. it was `wrap_content`), this will return the same aspect ratio of CameraView.|
 |`getSnapshotSize()`|Returns `getPreviewSize()`, since a snapshot is a preview frame.|
 |`getPictureSize()`|Returns the size of the output picture. The aspect ratio is consistent with `getPreviewSize()`.|
+|`setVideoMaxSize(long)`|Set a max file size (in bytes) for a video recording. There is no file size limit by default unless set by the user.|
 
 Take also a look at public methods in `CameraUtils`, `CameraOptions`, `ExtraProperties`.
 

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
@@ -19,16 +19,13 @@ import org.mockito.stubbing.Stubber;
 
 import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -137,11 +134,11 @@ public class CameraViewCallbacksTest extends BaseTest {
 
     @Test
     public void testDispatchOnVideoTaken() {
-        completeTask().when(listener).onVideoTaken(null);
-        camera.mCameraCallbacks.dispatchOnVideoTaken(null);
+        completeTask().when(listener).onVideoTaken(null, false);
+        camera.mCameraCallbacks.dispatchOnVideoTaken(null, false);
 
         assertNotNull(task.await(200));
-        verify(listener, times(1)).onVideoTaken(null);
+        verify(listener, times(1)).onVideoTaken(null, false);
     }
 
     @Test

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewCallbacksTest.java
@@ -134,11 +134,11 @@ public class CameraViewCallbacksTest extends BaseTest {
 
     @Test
     public void testDispatchOnVideoTaken() {
-        completeTask().when(listener).onVideoTaken(null, false);
-        camera.mCameraCallbacks.dispatchOnVideoTaken(null, false);
+        completeTask().when(listener).onVideoTaken(null);
+        camera.mCameraCallbacks.dispatchOnVideoTaken(null);
 
         assertNotNull(task.await(200));
-        verify(listener, times(1)).onVideoTaken(null, false);
+        verify(listener, times(1)).onVideoTaken(null);
     }
 
     @Test

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -3,7 +3,6 @@ package com.otaliastudios.cameraview;
 
 import android.graphics.Bitmap;
 import android.graphics.PointF;
-import android.media.MediaRecorder;
 import android.support.test.filters.MediumTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -20,8 +19,13 @@ import java.io.File;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -120,7 +124,7 @@ public class IntegrationTest extends BaseTest {
 
     private void waitForVideoEnd(boolean expectSuccess) {
         final Task<Boolean> video = new Task<>(true);
-        doEndTask(video, true).when(listener).onVideoTaken(any(File.class));
+        doEndTask(video, true).when(listener).onVideoTaken(any(File.class), false);
         Boolean result = video.await(8000);
         if (expectSuccess) {
             assertNotNull("Can take video", result);

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -124,7 +124,7 @@ public class IntegrationTest extends BaseTest {
 
     private void waitForVideoEnd(boolean expectSuccess) {
         final Task<Boolean> video = new Task<>(true);
-        doEndTask(video, true).when(listener).onVideoTaken(any(File.class), false);
+        doEndTask(video, true).when(listener).onVideoTaken(any(File.class));
         Boolean result = video.await(8000);
         if (expectSuccess) {
             assertNotNull("Can take video", result);

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
@@ -131,4 +131,14 @@ public class MockCameraController extends CameraController {
     @Override
     public void onBufferAvailable(byte[] buffer) {
     }
+
+    @Override
+    void setMaxFileSize(long maxFileSizeInBytes) {
+
+    }
+
+    @Override
+    boolean isRecordingVideo() {
+        return false;
+    }
 }

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
@@ -126,12 +126,7 @@ public class MockCameraController extends CameraController {
     }
 
     @Override
-    void setMaxFileSize(long maxFileSizeInBytes) {
+    void setVideoMaxSize(long videoMaxSizeInBytes) {
 
-    }
-
-    @Override
-    boolean isRecordingVideo() {
-        return false;
     }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -640,11 +640,9 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
             mMediaRecorder = null;
         }
         if (mVideoFile != null) {
-            mCameraCallbacks.dispatchOnVideoTaken(mVideoFile, mHasReachedMaxSize);
+            mCameraCallbacks.dispatchOnVideoTaken(mVideoFile);
             mVideoFile = null;
         }
-
-        mHasReachedMaxSize = false;
     }
 
     @WorkerThread
@@ -680,8 +678,8 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         mMediaRecorder.setOrientationHint(computeSensorToOutputOffset());
 
         //If the user sets a max file size, set it to the max file size
-        if(mMaxFileSizeInBytes > 0) {
-            mMediaRecorder.setMaxFileSize(mMaxFileSizeInBytes);
+        if(mVideoMaxSizeInBytes > 0) {
+            mMediaRecorder.setMaxFileSize(mVideoMaxSizeInBytes);
 
             //Attach a listener to the media recorder to listen for file size notifications
             mMediaRecorder.setOnInfoListener(new MediaRecorder.OnInfoListener() {
@@ -689,8 +687,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                 public void onInfo(MediaRecorder mediaRecorder, int i, int i1) {
                     switch (i){
                         case MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED:{
-                            mHasReachedMaxSize = true;
-                            endVideo();
+                            endVideoImmediately();
                             break;
                         }
                     }
@@ -857,16 +854,11 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
     }
 
     @Override
-    void setMaxFileSize(long maxFileSizeInBytes) {
-        mMaxFileSizeInBytes = maxFileSizeInBytes;
+    void setVideoMaxSize(long videoMaxSizeInBytes) {
+        mVideoMaxSizeInBytes = videoMaxSizeInBytes;
     }
 
     // -----------------
     // Additional helper info
-
-    @Override
-    boolean isRecordingVideo() {
-        return mIsCapturingVideo;
-    }
 }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
@@ -116,12 +116,7 @@ class Camera2 extends CameraController {
     }
 
     @Override
-    void setMaxFileSize(long maxFileSizeInBytes) {
+    void setVideoMaxSize(long videoMaxSizeInBytes) {
 
-    }
-
-    @Override
-    boolean isRecordingVideo() {
-        return false;
     }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
@@ -1,23 +1,12 @@
 package com.otaliastudios.cameraview;
 
 import android.annotation.TargetApi;
-import android.content.Context;
-import android.graphics.ImageFormat;
 import android.graphics.PointF;
-import android.hardware.camera2.CameraAccessException;
-import android.hardware.camera2.CameraCharacteristics;
-import android.hardware.camera2.CameraDevice;
-import android.hardware.camera2.CameraManager;
-import android.hardware.camera2.params.StreamConfigurationMap;
 import android.location.Location;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 @TargetApi(21)
 class Camera2 extends CameraController {
@@ -129,5 +118,15 @@ class Camera2 extends CameraController {
     @Override
     public void onBufferAvailable(byte[] buffer) {
 
+    }
+
+    @Override
+    void setMaxFileSize(long maxFileSizeInBytes) {
+
+    }
+
+    @Override
+    boolean isRecordingVideo() {
+        return false;
     }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -64,10 +64,9 @@ abstract class CameraController implements
 
     protected boolean mIsCapturingImage = false;
     protected boolean mIsCapturingVideo = false;
-    protected boolean mHasReachedMaxSize = false;
 
     protected int mState = STATE_STOPPED;
-    protected long mMaxFileSizeInBytes = 0;
+    protected long mVideoMaxSizeInBytes = 0;
 
     // Used for testing.
     Task<Void> mZoomTask = new Task<>();
@@ -319,9 +318,7 @@ abstract class CameraController implements
 
     abstract void startAutoFocus(@Nullable Gesture gesture, PointF point);
 
-    abstract void setMaxFileSize(long maxFileSizeInBytes);
-
-    abstract boolean isRecordingVideo();
+    abstract void setVideoMaxSize(long videoMaxSizeInBytes);
 
     //endregion
 
@@ -387,6 +384,10 @@ abstract class CameraController implements
 
     final Size getPreviewSize() {
         return mPreviewSize;
+    }
+
+    final boolean isRecordingVideo() {
+        return mIsCapturingVideo;
     }
 
     //endregion

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -386,7 +386,7 @@ abstract class CameraController implements
         return mPreviewSize;
     }
 
-    final boolean isRecordingVideo() {
+    final boolean isCapturingVideo() {
         return mIsCapturingVideo;
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -315,6 +315,10 @@ abstract class CameraController implements
 
     abstract void startAutoFocus(@Nullable Gesture gesture, PointF point);
 
+    abstract void setMaxFileSize(long maxFileSizeInBytes);
+
+    abstract boolean isRecordingVideo();
+
     //endregion
 
     //region final getters

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -73,11 +73,9 @@ public abstract class CameraListener {
      * </code>
      *
      * @param video file hosting the mp4 video
-     * @param hasReachedMaxFileSize returns true if the user has set a max file size for videos and
-     *                                if the video ended because of the file size limit.
      */
     @UiThread
-    public void onVideoTaken(File video, boolean hasReachedMaxFileSize) {
+    public void onVideoTaken(File video) {
 
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -73,9 +73,11 @@ public abstract class CameraListener {
      * </code>
      *
      * @param video file hosting the mp4 video
+     * @param hasReachedMaxFileSize returns true if the user has set a max file size for videos and
+     *                                if the video ended because of the file size limit.
      */
     @UiThread
-    public void onVideoTaken(File video) {
+    public void onVideoTaken(File video, boolean hasReachedMaxFileSize) {
 
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1233,7 +1233,7 @@ public class CameraView extends FrameLayout {
 
     /**
      * Stops capturing video, if there was a video record going on.
-     * This will fire {@link CameraListener#onVideoTaken(File, boolean)}.
+     * This will fire {@link CameraListener#onVideoTaken(File)}.
      */
     public void stopCapturingVideo() {
         mCameraController.endVideo();
@@ -1339,10 +1339,10 @@ public class CameraView extends FrameLayout {
      * Set a max file size (in bytes) for a video recording.  There is no file size limit by default
      * unless set by the user.
      *
-     * @param maxFileSizeInBytes The maximum size of videos in bytes
+     * @param videoMaxSizeInBytes The maximum size of videos in bytes
      */
-    public void setMaxFileSize(long maxFileSizeInBytes){
-        mCameraController.setMaxFileSize(maxFileSizeInBytes);
+    public void setVideoMaxSize(long videoMaxSizeInBytes){
+        mCameraController.setVideoMaxSize(videoMaxSizeInBytes);
     }
 
     /**
@@ -1364,7 +1364,7 @@ public class CameraView extends FrameLayout {
         void onShutter(boolean shouldPlaySound);
         void processImage(byte[] jpeg, boolean consistentWithView, boolean flipHorizontally);
         void processSnapshot(YuvImage image, boolean consistentWithView, boolean flipHorizontally);
-        void dispatchOnVideoTaken(File file, boolean hasReachedMaxFileSize);
+        void dispatchOnVideoTaken(File file);
         void dispatchOnFocusStart(@Nullable Gesture trigger, PointF where);
         void dispatchOnFocusEnd(@Nullable Gesture trigger, boolean success, PointF where);
         void dispatchOnZoomChanged(final float newValue, final PointF[] fingers);
@@ -1505,13 +1505,13 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
-        public void dispatchOnVideoTaken(final File video, final boolean hasReachedMaxFileSize) {
+        public void dispatchOnVideoTaken(final File video) {
             mLogger.i("dispatchOnVideoTaken", video);
             mUiHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     for (CameraListener listener : mListeners) {
-                        listener.onVideoTaken(video, hasReachedMaxFileSize);
+                        listener.onVideoTaken(video);
                     }
                 }
             });

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -144,6 +144,10 @@ public class CameraView extends FrameLayout {
         GestureAction pinchGesture = GestureAction.fromValue(a.getInteger(R.styleable.CameraView_cameraGesturePinch, GestureAction.DEFAULT_PINCH.value()));
         GestureAction scrollHorizontalGesture = GestureAction.fromValue(a.getInteger(R.styleable.CameraView_cameraGestureScrollHorizontal, GestureAction.DEFAULT_SCROLL_HORIZONTAL.value()));
         GestureAction scrollVerticalGesture = GestureAction.fromValue(a.getInteger(R.styleable.CameraView_cameraGestureScrollVertical, GestureAction.DEFAULT_SCROLL_VERTICAL.value()));
+
+        //Get max size
+        float cameraVideoMaxSize = a.getFloat(R.styleable.CameraView_cameraVideoMaxSize, -1);
+
         a.recycle();
 
         // Components
@@ -185,6 +189,11 @@ public class CameraView extends FrameLayout {
         mapGesture(Gesture.PINCH, pinchGesture);
         mapGesture(Gesture.SCROLL_HORIZONTAL, scrollHorizontalGesture);
         mapGesture(Gesture.SCROLL_VERTICAL, scrollVerticalGesture);
+
+        //Set camera video maxSize
+        if(cameraVideoMaxSize > 0) {
+            setVideoMaxSize((long)cameraVideoMaxSize);
+        }
 
         if (!isInEditMode()) {
             mOrientationHelper = new OrientationHelper(context, mCameraCallbacks);
@@ -1349,8 +1358,8 @@ public class CameraView extends FrameLayout {
      * Returns true if the camera is currently recording a video
      * @return boolean indicating if the camera is recording a video
      */
-    public boolean isRecordingVideo(){
-        return mCameraController.isRecordingVideo();
+    public boolean isCapturingVideo(){
+        return mCameraController.isCapturingVideo();
     }
 
     //endregion

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1232,7 +1232,7 @@ public class CameraView extends FrameLayout {
 
     /**
      * Stops capturing video, if there was a video record going on.
-     * This will fire {@link CameraListener#onVideoTaken(File)}.
+     * This will fire {@link CameraListener#onVideoTaken(File, boolean)}.
      */
     public void stopCapturingVideo() {
         mCameraController.endVideo();
@@ -1334,6 +1334,24 @@ public class CameraView extends FrameLayout {
         return mPlaySounds;
     }
 
+    /**
+     * Set a max file size (in bytes) for a video recording.  There is no file size limit by default
+     * unless set by the user.
+     *
+     * @param maxFileSizeInBytes The maximum size of videos in bytes
+     */
+    public void setMaxFileSize(long maxFileSizeInBytes){
+        mCameraController.setMaxFileSize(maxFileSizeInBytes);
+    }
+
+    /**
+     * Returns true if the camera is currently recording a video
+     * @return boolean indicating if the camera is recording a video
+     */
+    public boolean isRecordingVideo(){
+        return mCameraController.isRecordingVideo();
+    }
+
     //endregion
 
     //region Callbacks and dispatching
@@ -1345,7 +1363,7 @@ public class CameraView extends FrameLayout {
         void onShutter(boolean shouldPlaySound);
         void processImage(byte[] jpeg, boolean consistentWithView, boolean flipHorizontally);
         void processSnapshot(YuvImage image, boolean consistentWithView, boolean flipHorizontally);
-        void dispatchOnVideoTaken(File file);
+        void dispatchOnVideoTaken(File file, boolean hasReachedMaxFileSize);
         void dispatchOnFocusStart(@Nullable Gesture trigger, PointF where);
         void dispatchOnFocusEnd(@Nullable Gesture trigger, boolean success, PointF where);
         void dispatchOnZoomChanged(final float newValue, final PointF[] fingers);
@@ -1492,13 +1510,13 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
-        public void dispatchOnVideoTaken(final File video) {
+        public void dispatchOnVideoTaken(final File video, final boolean hasReachedMaxFileSize) {
             mLogger.i("dispatchOnVideoTaken", video);
             mUiHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     for (CameraListener listener : mListeners) {
-                        listener.onVideoTaken(video);
+                        listener.onVideoTaken(video, hasReachedMaxFileSize);
                     }
                 }
             });

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -110,6 +110,8 @@
 
         <attr name="cameraPlaySounds" format="boolean" />
 
+        <attr name="cameraVideoMaxSize" format="float" />
+
         <!-- deprecated attr name="cameraZoomMode" format="enum">
             <enum name="off" value="0" />
             <enum name="pinch" value="1" />

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
@@ -49,8 +49,8 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
             public void onPictureTaken(byte[] jpeg) { onPicture(jpeg); }
 
             @Override
-            public void onVideoTaken(File video, boolean hasReachedMaxFileSize) {
-                super.onVideoTaken(video, hasReachedMaxFileSize);
+            public void onVideoTaken(File video) {
+                super.onVideoTaken(video);
                 onVideo(video);
             }
         });

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
@@ -7,24 +7,18 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import com.otaliastudios.cameraview.Audio;
 import com.otaliastudios.cameraview.CameraListener;
 import com.otaliastudios.cameraview.CameraLogger;
 import com.otaliastudios.cameraview.CameraOptions;
 import com.otaliastudios.cameraview.CameraView;
-import com.otaliastudios.cameraview.Flash;
-import com.otaliastudios.cameraview.Grid;
 import com.otaliastudios.cameraview.SessionType;
 import com.otaliastudios.cameraview.Size;
-import com.otaliastudios.cameraview.VideoQuality;
-import com.otaliastudios.cameraview.WhiteBalance;
 
 import java.io.File;
 
@@ -53,7 +47,12 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
         camera.addCameraListener(new CameraListener() {
             public void onCameraOpened(CameraOptions options) { onOpened(); }
             public void onPictureTaken(byte[] jpeg) { onPicture(jpeg); }
-            public void onVideoTaken(File video) { onVideo(video); }
+
+            @Override
+            public void onVideoTaken(File video, boolean hasReachedMaxFileSize) {
+                super.onVideoTaken(video, hasReachedMaxFileSize);
+                onVideo(video);
+            }
         });
 
         findViewById(R.id.edit).setOnClickListener(this);


### PR DESCRIPTION
Hello, 

I had a need to set a max file size limit for my implementation of the camera and added the API to set a limit. I added a new API method `setMaxFileSize(long maxFileSizeInBytes)` to set a custom maximum file size for a video recording. The camera ignores the max file size if its not set or is invalid. 

I added another boolean parameter to the video callback method indicating if the video ended due to a file size limit. I also included a helper getter method to get the status of the current camera video recording. It felt easier as I could rely on `cameraView.isRecordingVideo()` instead of having my own boolean tracking in my activity.

Thanks!