### PR TITLE
Change the offset computation for front cameras

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -406,8 +406,9 @@ abstract class CameraController implements
      */
     protected final int computeSensorToViewOffset() {
         if (mFacing == Facing.FRONT) {
-            // or: (360 - ((mSensorOffset + mDisplayOffset) % 360)) % 360;
-            return ((mSensorOffset - mDisplayOffset) + 360 + 180) % 360;
+            // Here we had ((mSensorOffset - mDisplayOffset) + 360 + 180) % 360
+            // And it seemed to give the same results for various combinations, but not for all (e.g. 0 - 270).
+            return (360 - ((mSensorOffset + mDisplayOffset) % 360)) % 360;
         } else {
             return (mSensorOffset - mDisplayOffset + 360) % 360;
         }


### PR DESCRIPTION
This should fix #108 and possibly not break anything else.

The old formula was giving correct results for `sensorOffset = 90` and `sensorOffset = 270`, but not in the other cases (`0` and `180`). That might be the reason why no-one has been reporting it.