### PR TITLE
Fix camera mute

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -3,6 +3,8 @@ package com.otaliastudios.cameraview;
 
 import android.graphics.Bitmap;
 import android.graphics.PointF;
+import android.hardware.Camera;
+import android.os.Build;
 import android.support.test.filters.MediumTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -362,6 +364,25 @@ public class IntegrationTest extends BaseTest {
         assertEquals(camera.getLocation().getLatitude(), 10d, 0d);
         assertEquals(camera.getLocation().getLongitude(), 2d, 0d);
         // This also ensures there are no crashes when attaching it to camera parameters.
+    }
+
+    @Test
+    public void testSetPlaySounds() {
+        controller.mPlaySoundsTask.listen();
+        boolean oldValue = camera.getPlaySounds();
+        boolean newValue = !oldValue;
+        camera.setPlaySounds(newValue);
+        controller.mPlaySoundsTask.await(300);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Camera.CameraInfo info = new Camera.CameraInfo();
+            Camera.getCameraInfo(camera.getCameraId(), info);
+            if (info.canDisableShutterSound) {
+                assertEquals(newValue, camera.getPlaySounds());
+            }
+        } else {
+            assertEquals(oldValue, camera.getPlaySounds());
+        }
     }
 
     //endregion

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/MockCameraController.java
@@ -129,4 +129,9 @@ public class MockCameraController extends CameraController {
     void setVideoMaxSize(long videoMaxSizeInBytes) {
 
     }
+
+    @Override
+    void setPlaySounds(boolean playSounds) {
+
+    }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -180,7 +180,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
             mergeLocation(params, null);
             mergeWhiteBalance(params, WhiteBalance.DEFAULT);
             mergeHdr(params, Hdr.DEFAULT);
-            mergePlaySound(true);
+            mergePlaySound(mPlaySounds);
             params.setRecordingHint(mSessionType == SessionType.VIDEO);
             mCamera.setParameters(params);
 
@@ -374,10 +374,13 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             Camera.CameraInfo info = new Camera.CameraInfo();
             Camera.getCameraInfo(mCameraId, info);
-            if (info.canDisableShutterSound && isCameraAvailable()) {
+            if (info.canDisableShutterSound) {
                 mCamera.enableShutterSound(mPlaySounds);
                 return true;
             }
+        }
+        if (mPlaySounds) {
+            return true;
         }
         mPlaySounds = oldPlaySound;
         return false;
@@ -886,9 +889,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         schedule(null, true, new Runnable() {
             @Override
             public void run() {
-                if (!mergePlaySound(old)) {
-                    mPlaySounds = old;
-                }
+                mergePlaySound(old);
             }
         });
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -886,7 +886,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
     void setPlaySounds(boolean playSounds) {
         final boolean old = mPlaySounds;
         mPlaySounds = playSounds;
-        schedule(null, true, new Runnable() {
+        schedule(mPlaySoundsTask, true, new Runnable() {
             @Override
             public void run() {
                 mergePlaySound(old);

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -371,11 +371,11 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
 
     @TargetApi(17)
     private void applyPlaySound() {
-        if (!mPlaySounds && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             Camera.CameraInfo info = new Camera.CameraInfo();
             Camera.getCameraInfo(mCameraId, info);
-            if (isCameraAvailable() && info.canDisableShutterSound) {
-                mCamera.enableShutterSound(false);
+            if (info.canDisableShutterSound && isCameraAvailable()) {
+                mCamera.enableShutterSound(mPlaySounds);
             }
         }
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -1,5 +1,6 @@
 package com.otaliastudios.cameraview;
 
+import android.annotation.TargetApi;
 import android.graphics.ImageFormat;
 import android.graphics.PointF;
 import android.graphics.Rect;
@@ -9,6 +10,7 @@ import android.hardware.Camera;
 import android.location.Location;
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
@@ -178,6 +180,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
             mergeLocation(params, null);
             mergeWhiteBalance(params, WhiteBalance.DEFAULT);
             mergeHdr(params, Hdr.DEFAULT);
+            applyPlaySound();
             params.setRecordingHint(mSessionType == SessionType.VIDEO);
             mCamera.setParameters(params);
 
@@ -364,6 +367,17 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         }
         mHdr = oldHdr;
         return false;
+    }
+
+    @TargetApi(17)
+    private void applyPlaySound() {
+        if (!mPlaySounds && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Camera.CameraInfo info = new Camera.CameraInfo();
+            Camera.getCameraInfo(mCameraId, info);
+            if (isCameraAvailable() && info.canDisableShutterSound) {
+                mCamera.enableShutterSound(false);
+            }
+        }
     }
 
 
@@ -572,15 +586,19 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
     private boolean isCameraAvailable() {
         switch (mState) {
             // If we are stopped, don't.
-            case STATE_STOPPED: return false;
+            case STATE_STOPPED:
+                return false;
             // If we are going to be closed, don't act on camera.
             // Even if mCamera != null, it might have been released.
-            case STATE_STOPPING: return false;
+            case STATE_STOPPING:
+                return false;
             // If we are started, mCamera should never be null.
-            case STATE_STARTED: return true;
+            case STATE_STARTED:
+                return true;
             // If we are starting, theoretically we could act.
             // Just check that camera is available.
-            case STATE_STARTING: return mCamera != null;
+            case STATE_STARTING:
+                return mCamera != null;
         }
         return false;
     }
@@ -678,15 +696,15 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         mMediaRecorder.setOrientationHint(computeSensorToOutputOffset());
 
         //If the user sets a max file size, set it to the max file size
-        if(mVideoMaxSizeInBytes > 0) {
+        if (mVideoMaxSizeInBytes > 0) {
             mMediaRecorder.setMaxFileSize(mVideoMaxSizeInBytes);
 
             //Attach a listener to the media recorder to listen for file size notifications
             mMediaRecorder.setOnInfoListener(new MediaRecorder.OnInfoListener() {
                 @Override
                 public void onInfo(MediaRecorder mediaRecorder, int i, int i1) {
-                    switch (i){
-                        case MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED:{
+                    switch (i) {
+                        case MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED: {
                             endVideoImmediately();
                             break;
                         }
@@ -856,6 +874,12 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
     @Override
     void setVideoMaxSize(long videoMaxSizeInBytes) {
         mVideoMaxSizeInBytes = videoMaxSizeInBytes;
+    }
+
+    @Override
+    void setPlaySounds(boolean playSounds) {
+        mPlaySounds = playSounds;
+        applyPlaySound();
     }
 
     // -----------------

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera2.java
@@ -119,4 +119,9 @@ class Camera2 extends CameraController {
     void setVideoMaxSize(long videoMaxSizeInBytes) {
 
     }
+
+    @Override
+    void setPlaySounds(boolean playSounds) {
+
+    }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -45,6 +45,7 @@ abstract class CameraController implements
     protected Audio mAudio;
     protected float mZoomValue;
     protected float mExposureCorrectionValue;
+    protected boolean mPlaySounds;
 
     protected int mCameraId;
     protected ExtraProperties mExtraProperties;
@@ -319,6 +320,8 @@ abstract class CameraController implements
     abstract void startAutoFocus(@Nullable Gesture gesture, PointF point);
 
     abstract void setVideoMaxSize(long videoMaxSizeInBytes);
+
+    abstract void setPlaySounds(boolean playSounds);
 
     //endregion
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -78,6 +78,7 @@ abstract class CameraController implements
     Task<Void> mLocationTask = new Task<>();
     Task<Void> mVideoQualityTask = new Task<>();
     Task<Void> mStartVideoTask = new Task<>();
+    Task<Void> mPlaySoundsTask = new Task<>();
 
     CameraController(CameraView.CameraCallbacks callback) {
         mCameraCallbacks = callback;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -488,7 +488,7 @@ abstract class CameraController implements
                 SizeSelectors.minWidth(targetMinSize.getWidth()));
         SizeSelector matchAll = SizeSelectors.or(
                 SizeSelectors.and(matchRatio, matchSize),
-                matchRatio, // If couldn't match both, match ratio.
+                SizeSelectors.and(matchRatio, SizeSelectors.biggest()), // If couldn't match both, match ratio and biggest.
                 SizeSelectors.biggest() // If couldn't match any, take the biggest.
         );
         Size result = matchAll.select(previewSizes).get(0);

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1706,5 +1706,10 @@ public class CameraView extends FrameLayout {
         return mCameraController.getFlash();
     }
 
+
+    /* for tests */int getCameraId(){
+        return mCameraController.mCameraId;
+    }
+
     //endregion
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1361,6 +1361,7 @@ public class CameraView extends FrameLayout {
      */
     public void setPlaySounds(boolean playSounds) {
         mPlaySounds = playSounds && Build.VERSION.SDK_INT >= 16;
+        mCameraController.setPlaySounds(playSounds);
     }
 
     /**


### PR DESCRIPTION
On some devices even if playSounds = "false" the shutter sound is still played. This pull request handles this issue on those devices where it's possible to mute programmatically:  
    `if (info.canDisableShutterSound)`