### PR TITLE
Migrate to new Android Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         // https://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
         // https://www.theguardian.com/technology/developer-blog/2016/dec/06/how-to-publish-an-android-library-a-mysterious-conversation
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
@@ -24,7 +24,7 @@ allprojects {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.1"
+    buildToolsVersion = "26.0.2"
     supportLibVersion = '26.1.0'
     minSdkVersion = 15
     targetSdkVersion = 26

--- a/cameraview/build.gradle
+++ b/cameraview/build.gradle
@@ -178,9 +178,7 @@ apply plugin: 'jacoco'
 
 def reportsDirectory = "$buildDir/reports/"
 jacoco {
-    // Using a different version might get 0 coverage reports.
-    // No time to investigate now.
-    toolVersion = "0.7.6.201602180812"
+    toolVersion = "0.7.4+"
     reportsDir = file(reportsDirectory)
 }
 

--- a/cameraview/build.gradle
+++ b/cameraview/build.gradle
@@ -39,17 +39,17 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
 
-    androidTestCompile 'com.android.support.test:runner:1.0.1'
-    androidTestCompile 'com.android.support.test:rules:1.0.1'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
+    androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 
-    compile "com.android.support:exifinterface:$supportLibVersion"
-    compile "com.android.support:support-annotations:$supportLibVersion"
+    implementation "com.android.support:exifinterface:$supportLibVersion"
+    implementation "com.android.support:support-annotations:$supportLibVersion"
 }
 
 //endregion

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile project(':cameraview')
-    compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile "com.android.support:design:$supportLibVersion"
+    implementation project(':cameraview')
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:design:$supportLibVersion"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip


### PR DESCRIPTION
I migrated to the new Android Gradle plugin to not longer leak the dependencies. With the old plugin you get a warning about different support library versions:
<img width="1362" alt="screen shot 2018-01-25 at 15 57 38" src="https://user-images.githubusercontent.com/9310224/35395186-f2df5eb8-01e9-11e8-9794-a6c9e99b70c8.png">


More Info: [Migrate to Android Plugin for Gradle 3.0.0](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html)