### PR TITLE
Add: 3 second focus delay to resolve setParameters crash on Samsung.

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -30,12 +30,17 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
 
     private Camera mCamera;
     private boolean mIsBound = false;
+    private boolean mDelayRunnable = false;
 
     private final int mPostFocusResetDelay = 3000;
     private Runnable mPostFocusResetRunnable = new Runnable() {
         @Override
         public void run() {
             if (!isCameraAvailable()) return;
+            if (mDelayRunnable) {
+                mDelayRunnable = false; // Delay focus further - fixes Samsung devices
+                return;
+            }
             mCamera.cancelAutoFocus();
             Camera.Parameters params = mCamera.getParameters();
             params.setFocusAreas(null);
@@ -493,6 +498,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                 if (mIsCapturingVideo && !mCameraOptions.isVideoSnapshotSupported()) return;
 
                 mIsCapturingImage = true;
+                mDelayRunnable = true; // delaying focus (fixes crash on samsung)
                 final int sensorToOutput = computeSensorToOutputOffset();
                 final int sensorToView = computeSensorToViewOffset();
                 final boolean outputMatchesView = (sensorToOutput + sensorToView + 180) % 180 == 0;
@@ -805,6 +811,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                 mCamera.setParameters(params);
                 mCameraCallbacks.dispatchOnFocusStart(gesture, p);
                 // TODO this is not guaranteed to be called... Fix.
+                // TODO Updated: Kind of fixed with mDelayRunnable on image capture
                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                     @Override
                     public void onAutoFocus(boolean success, Camera camera) {


### PR DESCRIPTION
I've been facing the setParameters failed error on a Samsung Galaxy Note 4, ~~related to the following issue: https://github.com/natario1/CameraView/issues/138~~.

It appears to be triggered by a focus happening (maybe immediately?) while the camera is capturing a photo. I've added a quick workaround that just delays the autofocus runnable an extra loop, which resolves the issue on my device. Hope it helps towards putting together a proper solution.

I can only test on my OnePlus One and Samsung Galaxy Note 4 though, sorry!

Edit: After reviewing the ticket I linked, I don't think this resolves that problem. This really just resolves my device's problem where capturing an image crashes the app with "setParameters failed" when tap to focus enabled.