### PR TITLE
Callback to error in class Camera1

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -663,6 +663,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
             } catch (Exception e) {
                 // This can happen if endVideo() is called right after startVideo(). We don't care.
                 LOG.w("endVideoImmediately:", "Error while closing media recorder. Swallowing", e);
+                mCameraCallbacks.dispatchError(new CameraException(e));
             }
             mMediaRecorder.release();
             mMediaRecorder = null;


### PR DESCRIPTION
Issue: no callback to error
Class: Camera1

When code fails on
	Line: 586
		Camera1.this.mMediaRecorder.start();

Call
	Line: 591
		Camera1.this.endVideoImmediately();

But when code reach
	Line: 616
	this.mMediaRecorder.stop();

Fail again and don't have callback and only log the error

In the commit the update is
	Line: 619
		this.mCameraCallbacks.dispatchError(new CameraException(var2));


Error in log:

`04-04 17:21:12.620 21520-21570/mx.demo.demoapp E/MediaRecorder: start failed: -38
04-04 17:21:12.622 21520-21570/mx.demo.demoapp E/Camera1: Error while starting MediaRecorder. Swallowing. java.lang.IllegalStateException
                                                                      java.lang.IllegalStateException
                                                                          at android.media.MediaRecorder._start(Native Method)
                                                                          at android.media.MediaRecorder.start(MediaRecorder.java:1170)
                                                                          at com.otaliastudios.cameraview.Camera1$14.run(Camera1.java:632)
                                                                          at com.otaliastudios.cameraview.Camera1$2.run(Camera1.java:62)
                                                                          at android.os.Handler.handleCallback(Handler.java:751)
                                                                          at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                          at android.os.Looper.loop(Looper.java:154)
                                                                          at android.os.HandlerThread.run(HandlerThread.java:61)
04-04 17:21:12.623 21520-21570/mx.demo.demoapp I/Camera1: endVideoImmediately: is capturing: true
04-04 17:21:12.624 21520-21570/mx.demo.demoapp I/MediaRecorderJNI: stop
04-04 17:21:12.624 21520-21570/mx.demo.demoapp E/MediaRecorder: stop called in an invalid state: 0
04-04 17:21:12.625 21520-21570/mx.demo.demoapp W/Camera1: endVideoImmediately: Error while closing media recorder. Swallowing java.lang.IllegalStateException
                                                                      java.lang.IllegalStateException
                                                                          at android.media.MediaRecorder._stop(Native Method)
                                                                          at android.media.MediaRecorder.stop(MediaRecorder.java:1199)
                                                                          at com.otaliastudios.cameraview.Camera1.endVideoImmediately(Camera1.java:662)
                                                                          at com.otaliastudios.cameraview.Camera1.access$1500(Camera1.java:26)
                                                                          at com.otaliastudios.cameraview.Camera1$14.run(Camera1.java:637)
                                                                          at com.otaliastudios.cameraview.Camera1$2.run(Camera1.java:62)
                                                                          at android.os.Handler.handleCallback(Handler.java:751)
                                                                          at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                          at android.os.Looper.loop(Looper.java:154)
                                                                          at android.os.HandlerThread.run(HandlerThread.java:61)
04-04 17:21:12.626 21520-21570/mx.demo.demoapp I/CameraCallbacks: dispatchError com.otaliastudios.cameraview.CameraException: java.lang.IllegalStateException
                                                                              com.otaliastudios.cameraview.CameraException: java.lang.IllegalStateException
                                                                                  at com.otaliastudios.cameraview.Camera1.endVideoImmediately(Camera1.java:666)
                                                                                  at com.otaliastudios.cameraview.Camera1.access$1500(Camera1.java:26)
                                                                                  at com.otaliastudios.cameraview.Camera1$14.run(Camera1.java:637)
                                                                                  at com.otaliastudios.cameraview.Camera1$2.run(Camera1.java:62)
                                                                                  at android.os.Handler.handleCallback(Handler.java:751)
                                                                                  at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                                  at android.os.Looper.loop(Looper.java:154)
                                                                                  at android.os.HandlerThread.run(HandlerThread.java:61)
                                                                               Caused by: java.lang.IllegalStateException
                                                                                  at android.media.MediaRecorder._stop(Native Method)
                                                                                  at android.media.MediaRecorder.stop(MediaRecorder.java:1199)
                                                                                  at com.otaliastudios.cameraview.Camera1.endVideoImmediately(Camera1.java:662)
                                                                                  at com.otaliastudios.cameraview.Camera1.access$1500(Camera1.java:26) 
                                                                                  at com.otaliastudios.cameraview.Camera1$14.run(Camera1.java:637) 
                                                                                  at com.otaliastudios.cameraview.Camera1$2.run(Camera1.java:62) 
                                                                                  at android.os.Handler.handleCallback(Handler.java:751) 
                                                                                  at android.os.Handler.dispatchMessage(Handler.java:95) 
                                                                                  at android.os.Looper.loop(Looper.java:154) 
                                                                                  at android.os.HandlerThread.run(HandlerThread.java:61) 
04-04 17:21:12.626 21520-21570/mx.demo.demoapp I/MediaRecorderJNI: release
`