### PR TITLE
Removed +1 from frame byte return

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/FrameManager.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/FrameManager.java
@@ -88,6 +88,6 @@ class FrameManager {
 
     private int getBufferSize(int bitsPerPixel, Size previewSize) {
         long sizeInBits = previewSize.getHeight() * previewSize.getWidth() * bitsPerPixel;
-        return (int) Math.ceil(sizeInBits / 8.0d) + 1;
+        return (int) Math.ceil(sizeInBits / 8.0d);
     }
 }


### PR DESCRIPTION
Removing the +1 in order to solve the mismatch between frame size and data size.