### PR TITLE
Fix crash when try open broken camera

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -269,8 +269,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         }
 
         LOG.e("Error inside the onError callback.", error);
-//        throw new CameraException(new RuntimeException(CameraLogger.lastMessage));
-        mCameraCallbacks.dispatchError(new CameraException(new RuntimeException(CameraLogger.lastMessage)));
+        throw new CameraException(new RuntimeException(CameraLogger.lastMessage));
     }
 
     @Override

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -269,7 +269,8 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         }
 
         LOG.e("Error inside the onError callback.", error);
-        throw new CameraException(new RuntimeException(CameraLogger.lastMessage));
+//        throw new CameraException(new RuntimeException(CameraLogger.lastMessage));
+        mCameraCallbacks.dispatchError(new CameraException(new RuntimeException(CameraLogger.lastMessage)));
     }
 
     @Override

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -181,9 +181,9 @@ abstract class CameraController implements
                     onStart();
                 } catch (Exception e) {
                     mCameraCallbacks.dispatchError(new CameraException(e));
-                } finally {
                     LOG.e("Error:", "returned from onStart() with Exception.", "Dispatching.", ss());
                     mState = STATE_STOPPED;
+                    return;
                 }
                 LOG.i("Start:", "returned from onStart().", "Dispatching.", ss());
                 mState = STATE_STARTED;
@@ -249,9 +249,9 @@ abstract class CameraController implements
                     onStart();
                 } catch (Exception e) {
                     mCameraCallbacks.dispatchError(new CameraException(e));
-                } finally {
                     LOG.e("Error Restart:", "returned from onStart() with Exception.", "Dispatching.", ss());
                     mState = STATE_STOPPED;
+                    return;
                 }
                 mState = STATE_STARTED;
                 LOG.i("Restart: returned from start. Dispatching. State:", ss());

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -177,7 +177,14 @@ abstract class CameraController implements
                 if (mState >= STATE_STARTING) return;
                 mState = STATE_STARTING;
                 LOG.i("Start:", "about to call onStart()", ss());
-                onStart();
+                try {
+                    onStart();
+                } catch (Exception e) {
+                    mCameraCallbacks.dispatchError(new CameraException(e));
+                } finally {
+                    LOG.e("Error:", "returned from onStart() with Exception.", "Dispatching.", ss());
+                    mState = STATE_STOPPED;
+                }
                 LOG.i("Start:", "returned from onStart().", "Dispatching.", ss());
                 mState = STATE_STARTED;
                 mCameraCallbacks.dispatchOnCameraOpened(mCameraOptions);
@@ -238,7 +245,14 @@ abstract class CameraController implements
 
                 LOG.i("Restart: about to start. State:", ss());
                 mState = STATE_STARTING;
-                onStart();
+                try {
+                    onStart();
+                } catch (Exception e) {
+                    mCameraCallbacks.dispatchError(new CameraException(e));
+                } finally {
+                    LOG.e("Error Restart:", "returned from onStart() with Exception.", "Dispatching.", ss());
+                    mState = STATE_STOPPED;
+                }
                 mState = STATE_STARTED;
                 LOG.i("Restart: returned from start. Dispatching. State:", ss());
                 mCameraCallbacks.dispatchOnCameraOpened(mCameraOptions);


### PR DESCRIPTION
When camera broken, we catch RuntimeException when called Camera.open() or getParameters().
I handle it in block try catch and call dispatchError.