### PR TITLE
Added function to retrieve the current camera orientation

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -269,6 +269,10 @@ abstract class CameraController implements
         mDisplayOffset = displayOffset;
     }
 
+    final int getDeviceOrientation() {
+        return mDeviceOrientation;
+    }
+
     // This can be called multiple times.
     final void setDeviceOrientation(int deviceOrientation) {
         mDeviceOrientation = deviceOrientation;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1288,6 +1288,14 @@ public class CameraView extends FrameLayout {
         });
     }
 
+    /**
+     * Returns the orientation of the camera.
+     * This is available after {@link CameraListener#onCameraOpened(CameraOptions)} has been called.
+     * @return Returns a value of 0, 90, 180 or 270.
+     */
+    public int getCameraOrientation() {
+        return (mCameraController.getDeviceOrientation() + mOrientationHelper.getDisplayOffset()) % 360;
+    }
 
     /**
      * Returns the size used for the preview,


### PR DESCRIPTION
We don't finish the activity containing our cameraview after a picture/video has been taken and go to a detail screen with the result. Because the cameraview is not active, it doesn't update it's orientation and we need to access the latest available orientation after camera opened.