### PR TITLE
Fixed issue #233. Exception on some devices when we use default videoCodec.

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -688,7 +688,11 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         mMediaRecorder.setOutputFormat(profile.fileFormat);
         mMediaRecorder.setVideoFrameRate(profile.videoFrameRate);
         mMediaRecorder.setVideoSize(profile.videoFrameWidth, profile.videoFrameHeight);
-        mMediaRecorder.setVideoEncoder(mMapper.map(mVideoCodec));
+        if (mVideoCodec == VideoCodec.DEFAULT) {
+            mMediaRecorder.setVideoEncoder(profile.videoCodec);
+        } else {
+            mMediaRecorder.setVideoEncoder(mMapper.map(mVideoCodec));
+        }
         mMediaRecorder.setVideoEncodingBitRate(profile.videoBitRate);
         if (mAudio == Audio.ON) {
             mMediaRecorder.setAudioChannels(profile.audioChannels);


### PR DESCRIPTION
Fixed Exception on some devices when we use default videoCodec instead CamcorderProfile videoCodec.
I had exception on Sony D5503 (API 22) in demo.
Issue GH-233