### PR TITLE
Error handling and lifecycle boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
-    - doc-27
+    - build-tools-28.0.2
+    - android-28
+    - doc-28
 
 install:
   # Setup

--- a/README.md
+++ b/README.md
@@ -92,8 +92,21 @@ To use the CameraView engine, simply add a `CameraView` to your layout:
     android:layout_height="wrap_content" />
 ```
 
-`CameraView` has lots of XML attributes, so keep reading. Make sure you override `onResume`,
-`onPause` and  `onDestroy` in your activity or fragment, and call `CameraView.start()`, `stop()`
+`CameraView` is a component bound to your activity or fragment lifecycle. This means that you must pass the 
+lifecycle owner using `setLifecycleOwner`: 
+
+```java
+@Override
+protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    CameraView camera = findViewById(R.id.camera);
+    camera.setLifecycleOwner(this);
+    // From fragments, use fragment.viewLifecycleOwner instead of this!
+}
+```
+
+For those who are not using the support libraries and the lifecycle implementation, make sure you override `onResume`,
+`onPause` and  `onDestroy` in your component, and call `CameraView.start()`, `stop()`
 and `destroy()`.
 
 ```java

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
 ext {
     compileSdkVersion = 28
     supportLibVersion = '28.0.0-rc02'
+    lifecycleVersion = '1.1.1'
     minSdkVersion = 15
     targetSdkVersion = 28
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-alpha15'
+        classpath 'com.android.tools.build:gradle:3.2.0-rc03'
         // https://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
         // https://www.theguardian.com/technology/developer-blog/2016/dec/06/how-to-publish-an-android-library-a-mysterious-conversation
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
     }
 }
 
@@ -23,11 +23,10 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 27
-    buildToolsVersion = "27.0.3"
-    supportLibVersion = '27.1.1'
+    compileSdkVersion = 28
+    supportLibVersion = '28.0.0-rc02'
     minSdkVersion = 15
-    targetSdkVersion = 27
+    targetSdkVersion = 28
 }
 
 task clean(type: Delete) {

--- a/cameraview/build.gradle
+++ b/cameraview/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     api "com.android.support:exifinterface:$supportLibVersion"
+    api "android.arch.lifecycle:common:$lifecycleVersion"
     implementation "com.android.support:support-annotations:$supportLibVersion"
 }
 

--- a/cameraview/build.gradle
+++ b/cameraview/build.gradle
@@ -10,7 +10,7 @@ group = 'com.otaliastudios'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    // buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -42,11 +42,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test:rules:1.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.google.dexmaker:dexmaker:1.2'
     androidTestImplementation 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     api "com.android.support:exifinterface:$supportLibVersion"
     implementation "com.android.support:support-annotations:$supportLibVersion"

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraException.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraException.java
@@ -6,7 +6,42 @@ package com.otaliastudios.cameraview;
  */
 public class CameraException extends RuntimeException {
 
+    /**
+     * Unknown error. No further info available.
+     */
+    public static final int REASON_UNKNOWN = 0;
+
+    /**
+     * We failed to connect to the camera service.
+     * The camera might be in use by another app.
+     */
+    public static final int REASON_FAILED_TO_CONNECT = 1;
+
+    /**
+     * Failed to start the camera preview.
+     * Again, the camera might be in use by another app.
+     */
+    public static final int REASON_FAILED_TO_START_PREVIEW = 2;
+
+    /**
+     * Camera was forced to disconnect.
+     * In Camera1, this is thrown when {@link android.hardware.Camera.CAMERA_ERROR_EVICTED}
+     * is caught.
+     */
+    public static final int REASON_DISCONNECTED = 3;
+
+    private int reason = REASON_UNKNOWN;
+
     CameraException(Throwable cause) {
         super(cause);
+    }
+
+    CameraException(Throwable cause, int reason) {
+        super(cause);
+        this.reason = reason;
+    }
+
+    public int getReason() {
+        return reason;
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    // buildToolsVersion rootProject.ext.buildToolsVersion
+
     defaultConfig {
         applicationId "com.otaliastudios.cameraview.demo"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
@@ -44,6 +44,7 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
         CameraLogger.setLogLevel(CameraLogger.LEVEL_VERBOSE);
 
         camera = findViewById(R.id.camera);
+        camera.setLifecycleOwner(this);
         camera.addCameraListener(new CameraListener() {
             public void onCameraOpened(CameraOptions options) { onOpened(); }
             public void onPictureTaken(byte[] jpeg) { onPicture(jpeg); }
@@ -196,25 +197,7 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
         return true;
     }
 
-    //region Boilerplate
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        camera.start();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        camera.stop();
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        camera.destroy();
-    }
+    //region Permissions
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {


### PR DESCRIPTION
- Update dependencies and android to v. 28
- Added `CameraException.getReason()` to know more about what has failed and why
- Catching exceptions for `Camera.open()` and `Camera.startPreview()` so app does not crash
- Implement `LifecycleObserver` to remove start, stop and destroy boilerplate