### PR TITLE
Fix OrientationHelper

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/OrientationHelperTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/OrientationHelperTest.java
@@ -90,5 +90,10 @@ public class OrientationHelperTest extends BaseTest {
         helper.mListener.onOrientationChanged(270);
         assertEquals(helper.getDeviceOrientation(), 270);
         verify(callback, times(1)).onDeviceOrientationChanged(270);
+
+        // It is still 270 after ORIENTATION_UNKNOWN
+        helper.mListener.onOrientationChanged(OrientationEventListener.ORIENTATION_UNKNOWN);
+        assertEquals(helper.getDeviceOrientation(), 270);
+        verify(callback, times(1)).onDeviceOrientationChanged(270);
     }
 }

--- a/cameraview/src/main/utils/com/otaliastudios/cameraview/OrientationHelper.java
+++ b/cameraview/src/main/utils/com/otaliastudios/cameraview/OrientationHelper.java
@@ -28,7 +28,7 @@ class OrientationHelper {
             public void onOrientationChanged(int orientation) {
                 int or = 0;
                 if (orientation == OrientationEventListener.ORIENTATION_UNKNOWN) {
-                    or = 0;
+                    or = mDeviceOrientation != -1 ? mDeviceOrientation : 0;
                 } else if (orientation >= 315 || orientation < 45) {
                     or = 0;
                 } else if (orientation >= 45 && orientation < 135) {


### PR DESCRIPTION
It is better to use a previous orientation value when a sensor returns ORIENTATION_UNKNOWN.
It will allow to make landscape photos when a device is almost parallel to the ground plane.