### PR TITLE
Fixed bug with deprecated method setBackgroundDrawable

### DIFF
--- a/cameraview/src/main/res/layout/cameraview_texture_view.xml
+++ b/cameraview/src/main/res/layout/cameraview_texture_view.xml
@@ -4,5 +4,6 @@
     android:id="@+id/texture_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:layout_gravity="center" />
+    android:layout_gravity="center"
+    android:background="@null"
+    android:gravity="center" />


### PR DESCRIPTION
solution from here - https://stackoverflow.com/a/47796036

Without this fix library throws "java.lang.UnsupportedOperationException: TextureView doesn't support displaying a background drawable" on target sdk 28