### PR TITLE
Readme.md: new gradle/android-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ addressing most of the common issues and needs, and still leaving you with flexi
 See [CHANGELOG](https://github.com/natario1/CameraView/blob/master/CHANGELOG.md).
 
 ```groovy
-compile 'com.otaliastudios:cameraview:1.6.0'
+implementation 'com.otaliastudios:cameraview:1.6.0'
 ```
 
 Make sure your project repositories include the `jcenter()`:

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-rc03'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         // https://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
         // https://www.theguardian.com/technology/developer-blog/2016/dec/06/how-to-publish-an-android-library-a-mysterious-conversation
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -22,7 +22,8 @@ android {
 }
 
 dependencies {
-    implementation project(':cameraview')
+    //implementation project(':cameraview')
+    implementation 'com.otaliastudios:cameraview:+'
     implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.android.support:design:$supportLibVersion"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':demo', ':cameraview'
+include ':demo'


### PR DESCRIPTION
uses "implementation" instead of "compile" for dependencies