### PR TITLE
Handle autoFocus exceptions (issue #181)

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -823,15 +823,22 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                 mCamera.setParameters(params);
                 mCameraCallbacks.dispatchOnFocusStart(gesture, p);
                 // TODO this is not guaranteed to be called... Fix.
-                mCamera.autoFocus(new Camera.AutoFocusCallback() {
-                    @Override
-                    public void onAutoFocus(boolean success, Camera camera) {
-                        // TODO lock auto exposure and white balance for a while
-                        mCameraCallbacks.dispatchOnFocusEnd(gesture, success, p);
-                        mHandler.get().removeCallbacks(mPostFocusResetRunnable);
-                        mHandler.get().postDelayed(mPostFocusResetRunnable, mPostFocusResetDelay);
-                    }
-                });
+                try {
+                    mCamera.autoFocus(new Camera.AutoFocusCallback() {
+                        @Override
+                        public void onAutoFocus(boolean success, Camera camera) {
+                            // TODO lock auto exposure and white balance for a while
+                            mCameraCallbacks.dispatchOnFocusEnd(gesture, success, p);
+                            mHandler.get().removeCallbacks(mPostFocusResetRunnable);
+                            mHandler.get().postDelayed(mPostFocusResetRunnable, mPostFocusResetDelay);
+                        }
+                    });
+                } catch (RuntimeException e) {
+                    // Handling random auto-focus exception on some devices
+                    // See https://github.com/natario1/CameraView/issues/181
+                    LOG.e("startAutoFocus:", "Error calling autoFocus", e);
+                    mCameraCallbacks.dispatchOnFocusEnd(gesture, false, p);
+                }
             }
         });
     }


### PR DESCRIPTION
Fix for [autoFocus failed in tablets #181](https://github.com/natario1/CameraView/issues/181)

The tldr version is that some devices (including Galaxy Tab A 7.0" 2016 and lots of Sony phones like Xperia Z, Z1, V, ...) occasionally throw Runtime exceptions when calling autoFocus.
It doesn't seem that we can do much about. So, let's at least handle the exception and prevent the crash and user can trigger the focus later if required.