### PR TITLE
Fixed preview orientation & size when device is rotated

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -157,6 +157,16 @@ public class IntegrationTest extends BaseTest {
 
     //region test open/close
 
+
+    @Test
+    public void testPreviewSizeOnOrientationChange() {
+        waitForOpen(true);
+        controller.setDeviceOrientation(90);
+        assertTrue(controller.mPreviewSize.getWidth() > controller.mPreviewSize.getHeight());
+        controller.setDeviceOrientation(0);
+        assertTrue(controller.mPreviewSize.getWidth() < controller.mPreviewSize.getHeight());
+    }
+
     @Test
     public void testOpenClose() throws Exception {
         // Starting and stopping are hard to get since they happen on another thread.

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/IntegrationTest.java
@@ -88,6 +88,15 @@ public class IntegrationTest extends BaseTest {
         controller.mCrashHandler = crashThread.get();
     }
 
+    @Test
+    public void testPreviewOrientationOnRotation(){
+        waitForOpen(true);
+        controller.setDeviceOrientation(270);
+        assertEquals(controller.getCameraOrientation(), 0);
+        controller.setDeviceOrientation(0);
+        assertEquals(controller.getCameraOrientation(), 90);
+    }
+
     @After
     public void tearDown() throws Exception {
         camera.stopVideo();
@@ -158,14 +167,7 @@ public class IntegrationTest extends BaseTest {
     //region test open/close
 
 
-    @Test
-    public void testPreviewSizeOnOrientationChange() {
-        waitForOpen(true);
-        controller.setDeviceOrientation(90);
-        assertTrue(controller.mPreviewSize.getWidth() > controller.mPreviewSize.getHeight());
-        controller.setDeviceOrientation(0);
-        assertTrue(controller.mPreviewSize.getWidth() < controller.mPreviewSize.getHeight());
-    }
+
 
     @Test
     public void testOpenClose() throws Exception {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -161,6 +161,19 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
         return isCameraAvailable() && mIsBound;
     }
 
+
+     void setDeviceOrientation(int deviceOrientation) {
+        super.setDeviceOrientation(deviceOrientation);
+        if (mCamera != null && mPreview != null) {
+            if (this.getDeviceOrientation() == 270)
+                mCamera.setDisplayOrientation(0);
+            else if (this.getDeviceOrientation() == 90)
+                mCamera.setDisplayOrientation(180);
+            else if (this.getDeviceOrientation() == 0)
+                mCamera.setDisplayOrientation(90);
+        }
+    }
+
     // To be called when the preview size is setup or changed.
     private void startPreview(String log) {
         LOG.i(log, "Dispatching onCameraPreviewSizeChanged.");
@@ -168,7 +181,16 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
 
         Size previewSize = getPreviewSize(REF_VIEW);
         boolean wasFlipped = flip(REF_SENSOR, REF_VIEW);
-        mPreview.setInputStreamSize(previewSize.getWidth(), previewSize.getHeight(), wasFlipped);
+        int width;
+        int height;
+        if (this.getDeviceOrientation() == 270 || this.getDeviceOrientation() == 90){
+            width = Math.max(previewSize.getHeight(), previewSize.getWidth());
+            height = Math.min(previewSize.getHeight(), previewSize.getWidth());
+        }else{
+            width = Math.min(previewSize.getHeight(), previewSize.getWidth());
+            height = Math.max(previewSize.getHeight(), previewSize.getWidth());
+        }
+        mPreview.setInputStreamSize(width,height, wasFlipped);
 
         Camera.Parameters params = mCamera.getParameters();
         mPreviewFormat = params.getPreviewFormat();

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -165,14 +165,21 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
      void setDeviceOrientation(int deviceOrientation) {
         super.setDeviceOrientation(deviceOrientation);
         if (mCamera != null && mPreview != null) {
-            if (this.getDeviceOrientation() == 270)
-                mCamera.setDisplayOrientation(0);
-            else if (this.getDeviceOrientation() == 90)
-                mCamera.setDisplayOrientation(180);
-            else if (this.getDeviceOrientation() == 0)
-                mCamera.setDisplayOrientation(90);
+            int cameraOrientation = getCameraOrientation();
+            mCamera.setDisplayOrientation(cameraOrientation);
         }
     }
+
+    public int getCameraOrientation(){
+        if (this.getDeviceOrientation() == 270)
+            return 0;
+        else if (this.getDeviceOrientation() == 90)
+           return 180;
+        else if (this.getDeviceOrientation() == 0)
+            return 90;
+        return 270;
+    }
+
 
     // To be called when the preview size is setup or changed.
     private void startPreview(String log) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -96,6 +96,10 @@ abstract class CameraController implements
         mPreview.setSurfaceCallback(this);
     }
 
+    public int getDeviceOrientation(){
+        return  mDeviceOrientation;
+    }
+
     //region Error handling
 
     private static class NoOpExceptionHandler implements Thread.UncaughtExceptionHandler {
@@ -275,7 +279,7 @@ abstract class CameraController implements
     }
 
     // This can be called multiple times.
-    final void setDeviceOrientation(int deviceOrientation) {
+    void setDeviceOrientation(int deviceOrientation) {
         mDeviceOrientation = deviceOrientation;
     }
 


### PR DESCRIPTION
Fixes [Incorrect preview orientation when device is rotated](https://github.com/natario1/CameraView/issues/375)

Solution works as follows:
Each time the device is rotated, the display orientation of the camera is recalculated and also the preview size is set depending on the orientation so that it does not appear stretched.