### PR TITLE
Add autofocus param

### DIFF
--- a/cameraview/build.gradle
+++ b/cameraview/build.gradle
@@ -131,7 +131,6 @@ bintray {
 //endregion
 
 //region javadoc and sources
-
 // From official sample https://github.com/bintray/bintray-examples/blob/master/gradle-aar-example/build.gradle
 task sourcesJar(type: Jar) {
     classifier = 'sources'

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -855,7 +855,7 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
 
 
     @Override
-    void startAutoFocus(@Nullable final Gesture gesture, @NonNull final PointF point) {
+    void startAutoFocus(@Nullable final Gesture gesture, @NonNull final PointF point, final Boolean autoReset) {
         // Must get width and height from the UI thread.
         int viewWidth = 0, viewHeight = 0;
         if (mPreview != null && mPreview.hasSurface()) {
@@ -891,7 +891,9 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                             // TODO lock auto exposure and white balance for a while
                             mCameraCallbacks.dispatchOnFocusEnd(gesture, success, p);
                             mHandler.get().removeCallbacks(mPostFocusResetRunnable);
-                            mHandler.get().postDelayed(mPostFocusResetRunnable, mPostFocusResetDelay);
+                            if (autoReset) {
+                                mHandler.get().postDelayed(mPostFocusResetRunnable, mPostFocusResetDelay);
+                            }
                         }
                     });
                 } catch (RuntimeException e) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -366,7 +366,7 @@ abstract class CameraController implements
 
     abstract void stopVideo();
 
-    abstract void startAutoFocus(@Nullable Gesture gesture, @NonNull PointF point);
+    abstract void startAutoFocus(@Nullable Gesture gesture, @NonNull PointF point, Boolean autoReset);
 
     abstract void setPlaySounds(boolean playSounds);
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -89,7 +89,7 @@ public abstract class CameraListener {
     /**
      * Notifies that user interacted with the screen and started focus with a gesture,
      * and the autofocus is trying to focus around that area. This can be used to draw things on screen.
-     * Can also be triggered by {@link CameraView#startAutoFocus(float, float)}.
+     * Can also be triggered by {@link CameraView#startAutoFocus(float, float, Boolean)}.
      *
      * @param point coordinates with respect to CameraView.getWidth() and CameraView.getHeight()
      */
@@ -103,7 +103,7 @@ public abstract class CameraListener {
      * Notifies that a gesture focus event just ended, and the camera converged
      * to a new focus (and possibly exposure and white balance).
      * This might succeed or not.
-     * Can also be triggered by {@link CameraView#startAutoFocus(float, float)}.
+     * Can also be triggered by {@link CameraView#startAutoFocus(float, float, Boolean)}.
      *
      * @param successful whether camera succeeded
      * @param point coordinates with respect to CameraView.getWidth() and CameraView.getHeight()

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -541,7 +541,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
 
             case FOCUS:
             case FOCUS_WITH_MARKER:
-                mCameraController.startAutoFocus(gesture, points[0]);
+                mCameraController.startAutoFocus(gesture, points[0], true);
                 break;
 
             case ZOOM:
@@ -1055,11 +1055,12 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
      *
      * @param x should be between 0 and getWidth()
      * @param y should be between 0 and getHeight()
+     * @param autoCancel true if auto focus should be cancelled once focused
      */
-    public void startAutoFocus(float x, float y) {
+    public void startAutoFocus(float x, float y, Boolean autoCancel) {
         if (x < 0 || x > getWidth()) throw new IllegalArgumentException("x should be >= 0 and <= getWidth()");
         if (y < 0 || y > getHeight()) throw new IllegalArgumentException("y should be >= 0 and <= getHeight()");
-        mCameraController.startAutoFocus(null, new PointF(x, y));
+        mCameraController.startAutoFocus(null, new PointF(x, y), autoCancel);
     }
 
 


### PR DESCRIPTION
Certain devices with low-end cameras are slow to perform auto-focus.  We use hundreds of them in the field to scan barcodes.  These changes add an additional parameter to startAutoFocus which will suppress the reset of auto-focus and retain the current focus for future scans.  This improves the experiences on these low end devices greatly.