### PR TITLE
Added setAutoFocusResetDelay to api to control autofocus reset options

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/Camera1.java
@@ -31,7 +31,6 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
     private Camera mCamera;
     private boolean mIsBound = false;
 
-    private final int mPostFocusResetDelay = 3000;
     private Runnable mPostFocusResetRunnable = new Runnable() {
         @Override
         public void run() {
@@ -891,7 +890,9 @@ class Camera1 extends CameraController implements Camera.PreviewCallback, Camera
                             // TODO lock auto exposure and white balance for a while
                             mCameraCallbacks.dispatchOnFocusEnd(gesture, success, p);
                             mHandler.get().removeCallbacks(mPostFocusResetRunnable);
-                            mHandler.get().postDelayed(mPostFocusResetRunnable, mPostFocusResetDelay);
+                            if (shouldResetAutoFocus()) {
+                                mHandler.get().postDelayed(mPostFocusResetRunnable, getAutoFocusResetDelay());
+                            }
                         }
                     });
                 } catch (RuntimeException e) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -72,7 +72,7 @@ abstract class CameraController implements
     protected Size mCaptureSize;
     protected Size mPreviewStreamSize;
     protected int mPreviewFormat;
-    protected long mAutoFocusResetDelayMillis = CameraView.DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS;
+    protected long mAutoFocusResetDelayMillis;
 
     protected int mSensorOffset;
     private int mDisplayOffset;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraController.java
@@ -72,6 +72,7 @@ abstract class CameraController implements
     protected Size mCaptureSize;
     protected Size mPreviewStreamSize;
     protected int mPreviewFormat;
+    protected long mAutoFocusResetDelayMillis = CameraView.DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS;
 
     protected int mSensorOffset;
     private int mDisplayOffset;
@@ -325,6 +326,8 @@ abstract class CameraController implements
         mSnapshotMaxHeight = maxHeight;
     }
 
+    final void setAutoFocusResetDelay(long delayMillis) { mAutoFocusResetDelayMillis = delayMillis; }
+
     //endregion
 
     //region Abstract setters and APIs
@@ -463,6 +466,12 @@ abstract class CameraController implements
 
     final boolean isTakingPicture() {
         return mPictureRecorder != null;
+    }
+
+    final long getAutoFocusResetDelay() { return mAutoFocusResetDelayMillis; }
+
+    final boolean shouldResetAutoFocus() {
+        return mAutoFocusResetDelayMillis > 0 && mAutoFocusResetDelayMillis != Long.MAX_VALUE;
     }
 
     //endregion

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -47,8 +47,8 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     private static final CameraLogger LOG = CameraLogger.create(TAG);
 
     public final static int PERMISSION_REQUEST_CODE = 16;
-    public final static long DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS = 3000;
 
+    final static long DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS = 3000;
     final static boolean DEFAULT_PLAY_SOUNDS = true;
 
     // Self managed parameters
@@ -114,7 +114,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         int videoMaxDuration = a.getInteger(R.styleable.CameraView_cameraVideoMaxDuration, 0);
         int videoBitRate = a.getInteger(R.styleable.CameraView_cameraVideoBitRate, 0);
         int audioBitRate = a.getInteger(R.styleable.CameraView_cameraAudioBitRate, 0);
-        long autoFocusResetDelay = (long) a.getFloat(R.styleable.CameraView_cameraAutoFocusResetDelay, DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS);
+        long autoFocusResetDelay = (long) a.getInteger(R.styleable.CameraView_cameraAutoFocusResetDelay, (int) DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS);
 
         // Picture size selector
         List<SizeSelector> pictureConstraints = new ArrayList<>(3);

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -47,6 +47,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     private static final CameraLogger LOG = CameraLogger.create(TAG);
 
     public final static int PERMISSION_REQUEST_CODE = 16;
+    public final static long DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS = 3000;
 
     final static boolean DEFAULT_PLAY_SOUNDS = true;
 
@@ -1047,6 +1048,24 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     public Audio getAudio() {
         return mCameraController.getAudio();
     }
+
+
+    /**
+     * the current delay in milliseconds to reset the focus after an autofocus process.
+     *
+     * @param cameraAutoFocusResetDelayMillis desired delay (in milliseconds).  If the delay
+     *                                        is less than or equal to 0 or equal to Long.MAX_VALUE,
+     *                                        the autofocus will not be reset.
+     */
+    public void setAutoFocusResetDelay(long cameraAutoFocusResetDelayMillis) {
+        mCameraController.setAutoFocusResetDelay(cameraAutoFocusResetDelayMillis);
+    }
+
+    /**
+     * Returns the current delay in milliseconds to reset the focus after an autofocus process.
+     * @return the current autofocus reset delay in milliseconds.
+     */
+    public long getAutoFocusResetDelay() { return mCameraController.getAutoFocusResetDelay(); }
 
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -114,6 +114,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         int videoMaxDuration = a.getInteger(R.styleable.CameraView_cameraVideoMaxDuration, 0);
         int videoBitRate = a.getInteger(R.styleable.CameraView_cameraVideoBitRate, 0);
         int audioBitRate = a.getInteger(R.styleable.CameraView_cameraAudioBitRate, 0);
+        long autoFocusResetDelay = (long) a.getFloat(R.styleable.CameraView_cameraAutoFocusResetDelay, DEFAULT_AUTOFOCUS_RESET_DELAY_MILLIS);
 
         // Picture size selector
         List<SizeSelector> pictureConstraints = new ArrayList<>(3);
@@ -220,6 +221,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         setVideoMaxSize(videoMaxSize);
         setVideoMaxDuration(videoMaxDuration);
         setVideoBitRate(videoBitRate);
+        setAutoFocusResetDelay(autoFocusResetDelay);
 
         // Apply gestures
         mapGesture(Gesture.TAP, tapGesture);
@@ -1051,14 +1053,14 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
 
 
     /**
-     * the current delay in milliseconds to reset the focus after an autofocus process.
+     * Sets the current delay in milliseconds to reset the focus after an autofocus process.
      *
-     * @param cameraAutoFocusResetDelayMillis desired delay (in milliseconds).  If the delay
-     *                                        is less than or equal to 0 or equal to Long.MAX_VALUE,
-     *                                        the autofocus will not be reset.
+     * @param delayMillis desired delay (in milliseconds).  If the delay
+     *                    is less than or equal to 0 or equal to Long.MAX_VALUE,
+     *                    the autofocus will not be reset.
      */
-    public void setAutoFocusResetDelay(long cameraAutoFocusResetDelayMillis) {
-        mCameraController.setAutoFocusResetDelay(cameraAutoFocusResetDelayMillis);
+    public void setAutoFocusResetDelay(long delayMillis) {
+        mCameraController.setAutoFocusResetDelay(delayMillis);
     }
 
     /**

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -124,5 +124,7 @@
 
         <attr name="cameraExperimental" format="boolean" />
 
+        <attr name="cameraAutoFocusResetDelay" format="float"/>
+
     </declare-styleable>
 </resources>

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -124,7 +124,7 @@
 
         <attr name="cameraExperimental" format="boolean" />
 
-        <attr name="cameraAutoFocusResetDelay" format="float"/>
+        <attr name="cameraAutoFocusResetDelay" format="integer|reference"/>
 
     </declare-styleable>
 </resources>

--- a/docs/_posts/2018-12-20-more-features.md
+++ b/docs/_posts/2018-12-20-more-features.md
@@ -65,10 +65,10 @@ This is useful for low end devices that have slow auto-focus capabilities.
 Defaults to 3 seconds.
 
 ```java
-cameraView.cameraAutoFocusResetDelay(1000);  // 1 second
-cameraView.cameraAutoFocusResetDelay(0);  // NO reset
-cameraView.cameraAutoFocusResetDelay(-1);  // NO reset
-cameraView.cameraAutoFocusResetDelay(Long.MAX_VALUE);  // NO reset
+cameraView.setCameraAutoFocusResetDelay(1000);  // 1 second
+cameraView.setCameraAutoFocusResetDelay(0);  // NO reset
+cameraView.setCameraAutoFocusResetDelay(-1);  // NO reset
+cameraView.setCameraAutoFocusResetDelay(Long.MAX_VALUE);  // NO reset
 
 
 ### UI Orientation

--- a/docs/_posts/2018-12-20-more-features.md
+++ b/docs/_posts/2018-12-20-more-features.md
@@ -15,7 +15,8 @@ disqus: 1
 <com.otaliastudios.cameraview.CameraView
     app:cameraPlaySounds="true|false"
     app:cameraGrid="off|draw3x3|draw4x4|drawPhi"
-    app:cameraGridColor="@color/black"/>
+    app:cameraGridColor="@color/black"
+    app:cameraAutoFocusResetDelay="0"/>
 ```
 
 ##### cameraPlaySounds
@@ -55,6 +56,20 @@ Defaults to a shade of grey.
 cameraView.setGridColor(Color.WHITE);
 cameraView.setGridColor(Color.BLACK);
 ```
+
+##### cameraAutoFocusResetDelay
+
+Lets you control how an auto-focus operation is reset after completed.
+Setting a value <= 0 or == Long.MAX_VALUE will not reset the auto-focus.
+This is useful for low end devices that have slow auto-focus capabilities.
+Defaults to 3 seconds.
+
+```java
+cameraView.cameraAutoFocusResetDelay(1000);  // 1 second
+cameraView.cameraAutoFocusResetDelay(0);  // NO reset
+cameraView.cameraAutoFocusResetDelay(-1);  // NO reset
+cameraView.cameraAutoFocusResetDelay(Long.MAX_VALUE);  // NO reset
+
 
 ### UI Orientation
 


### PR DESCRIPTION
Certain devices with low-end cameras are slow to perform auto-focus.  My changes add an additional parameter to startAutoFocus which will suppress the reset of auto-focus which will retain the current focus for future usages (scans, pictures, ...)