### PR TITLE
Fix for Video Start Callback delay

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -79,6 +79,7 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
     protected void onStart() {
         mPreview.addRendererFrameCallback(this);
         mDesiredState = STATE_RECORDING;
+        dispatchVideoRecordingStart();
     }
 
     @Override
@@ -240,7 +241,7 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
 
     @Override
     public void onEncodingStart() {
-        dispatchVideoRecordingStart();
+        //do nothing
     }
 
     @Override


### PR DESCRIPTION
### Problem
we were facing the delay in the callback for video record start in few devices this PR contains the fix for the same

- Tests: ... no
- Docs updated: ... *no*

### Solution
As discussed, moved the video start callback in SnapshotVideoRecorder from onEncodingStart to onStart. Since onStart gets called a bit early, the performance is better.
