### PR TITLE
Add support to record video to FileDescriptor.

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/VideoResultTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/VideoResultTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.FileDescriptor;
 
 import static org.junit.Assert.assertEquals;
 
@@ -27,7 +28,7 @@ public class VideoResultTest extends BaseTest {
     private VideoResult.Stub stub = new VideoResult.Stub();
 
     @Test
-    public void testResult() {
+    public void testResultWithFile() {
         File file = Mockito.mock(File.class);
         int rotation = 90;
         Size size = new Size(20, 120);
@@ -73,6 +74,66 @@ public class VideoResultTest extends BaseTest {
         assertEquals(result.getAudioBitRate(), audioBitRate);
         assertEquals(result.getAudio(), audio);
         assertEquals(result.getFacing(), facing);
+    }
 
+    @Test
+    public void testResultWithFileDescriptor() {
+        FileDescriptor fileDescriptor = FileDescriptor.in;
+        int rotation = 90;
+        Size size = new Size(20, 120);
+        VideoCodec codec = VideoCodec.H_263;
+        Location location = Mockito.mock(Location.class);
+        boolean isSnapshot = true;
+        int maxDuration = 1234;
+        long maxFileSize = 500000;
+        int reason = VideoResult.REASON_MAX_DURATION_REACHED;
+        int videoFrameRate = 30;
+        int videoBitRate = 300000;
+        int audioBitRate = 30000;
+        Audio audio = Audio.ON;
+        Facing facing = Facing.FRONT;
+
+        stub.fileDescriptor = fileDescriptor;
+        stub.rotation = rotation;
+        stub.size = size;
+        stub.videoCodec = codec;
+        stub.location = location;
+        stub.isSnapshot = isSnapshot;
+        stub.maxDuration = maxDuration;
+        stub.maxSize = maxFileSize;
+        stub.endReason = reason;
+        stub.videoFrameRate = videoFrameRate;
+        stub.videoBitRate = videoBitRate;
+        stub.audioBitRate = audioBitRate;
+        stub.audio = audio;
+        stub.facing = facing;
+
+        VideoResult result = new VideoResult(stub);
+        assertEquals(result.getFileDescriptor(), fileDescriptor);
+        assertEquals(result.getRotation(), rotation);
+        assertEquals(result.getSize(), size);
+        assertEquals(result.getVideoCodec(), codec);
+        assertEquals(result.getLocation(), location);
+        assertEquals(result.isSnapshot(), isSnapshot);
+        assertEquals(result.getMaxSize(), maxFileSize);
+        assertEquals(result.getMaxDuration(), maxDuration);
+        assertEquals(result.getTerminationReason(), reason);
+        assertEquals(result.getVideoFrameRate(), videoFrameRate);
+        assertEquals(result.getVideoBitRate(), videoBitRate);
+        assertEquals(result.getAudioBitRate(), audioBitRate);
+        assertEquals(result.getAudio(), audio);
+        assertEquals(result.getFacing(), facing);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testResultWithNoFile() {
+        VideoResult result = new VideoResult(stub);
+        result.getFile();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testResultWithNoFileDescriptor() {
+        VideoResult result = new VideoResult(stub);
+        result.getFileDescriptor();
     }
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
@@ -7,10 +7,11 @@ import com.otaliastudios.cameraview.controls.Facing;
 import com.otaliastudios.cameraview.controls.VideoCodec;
 import com.otaliastudios.cameraview.size.Size;
 
+import java.io.File;
+import java.io.FileDescriptor;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import java.io.File;
 
 /**
  * Wraps the result of a video recording started by {@link CameraView#takeVideo(File)}.
@@ -30,6 +31,7 @@ public class VideoResult {
         public int rotation;
         public Size size;
         public File file;
+        public FileDescriptor fileDescriptor;
         public Facing facing;
         public VideoCodec videoCodec;
         public Audio audio;
@@ -55,6 +57,7 @@ public class VideoResult {
     private final int rotation;
     private final Size size;
     private final File file;
+    private final FileDescriptor fileDescriptor;
     private final Facing facing;
     private final VideoCodec videoCodec;
     private final Audio audio;
@@ -71,6 +74,7 @@ public class VideoResult {
         rotation = builder.rotation;
         size = builder.size;
         file = builder.file;
+        fileDescriptor = builder.fileDescriptor;
         facing = builder.facing;
         videoCodec = builder.videoCodec;
         audio = builder.audio;
@@ -130,7 +134,23 @@ public class VideoResult {
      */
     @NonNull
     public File getFile() {
+        if (file == null) {
+            throw new RuntimeException("File is only available when takeVideo(File) is used.");
+        }
         return file;
+    }
+
+    /**
+     * Returns the file descriptor where the video was saved.
+     *
+     * @return the File Descriptor of this video
+     */
+    @NonNull
+    public FileDescriptor getFileDescriptor() {
+        if (fileDescriptor == null) {
+            throw new RuntimeException("FileDescriptor is only available when takeVideo(FileDescriptor) is used.");
+        }
+        return fileDescriptor;
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -38,6 +38,7 @@ import com.otaliastudios.cameraview.size.SizeSelectors;
 import com.otaliastudios.cameraview.video.VideoRecorder;
 
 import java.io.File;
+import java.io.FileDescriptor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -549,7 +550,9 @@ public abstract class CameraBaseEngine extends CameraEngine {
     }
 
     @Override
-    public final void takeVideo(final @NonNull VideoResult.Stub stub, final @NonNull File file) {
+    public final void takeVideo(final @NonNull VideoResult.Stub stub,
+                                final @Nullable File file,
+                                final @Nullable FileDescriptor fileDescriptor) {
         getOrchestrator().scheduleStateful("take video", CameraState.BIND, new Runnable() {
             @Override
             public void run() {
@@ -558,7 +561,13 @@ public abstract class CameraBaseEngine extends CameraEngine {
                 if (mMode == Mode.PICTURE) {
                     throw new IllegalStateException("Can't record video while in PICTURE mode");
                 }
-                stub.file = file;
+                if (file != null) {
+                    stub.file = file;
+                } else if (fileDescriptor != null) {
+                    stub.fileDescriptor = fileDescriptor;
+                } else {
+                    throw new IllegalStateException("file and fileDescriptor are both null.");
+                }
                 stub.isSnapshot = false;
                 stub.videoCodec = mVideoCodec;
                 stub.location = mLocation;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -49,6 +49,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.io.File;
+import java.io.FileDescriptor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -712,7 +713,9 @@ public abstract class CameraEngine implements
     public abstract void takePictureSnapshot(final @NonNull PictureResult.Stub stub);
 
     public abstract boolean isTakingVideo();
-    public abstract void takeVideo(@NonNull VideoResult.Stub stub, @NonNull File file);
+    public abstract void takeVideo(@NonNull VideoResult.Stub stub,
+                                   @Nullable File file,
+                                   @Nullable FileDescriptor fileDescriptor);
     public abstract void takeVideoSnapshot(@NonNull VideoResult.Stub stub, @NonNull File file);
     public abstract void stopVideo();
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -2,7 +2,6 @@ package com.otaliastudios.cameraview.video;
 
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
-import android.os.Handler;
 
 import com.otaliastudios.cameraview.CameraLogger;
 import com.otaliastudios.cameraview.VideoResult;
@@ -220,7 +219,15 @@ public abstract class FullVideoRecorder extends VideoRecorder {
                     (float) stub.location.getLatitude(),
                     (float) stub.location.getLongitude());
         }
-        mMediaRecorder.setOutputFile(stub.file.getAbsolutePath());
+
+        if (stub.file != null) {
+            mMediaRecorder.setOutputFile(stub.file.getAbsolutePath());
+        } else if (stub.fileDescriptor != null) {
+            mMediaRecorder.setOutputFile(stub.fileDescriptor);
+        } else {
+            throw new IllegalStateException("file and fileDescriptor are both null.");
+        }
+
         mMediaRecorder.setOrientationHint(stub.rotation);
         // When using MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED, the recorder might have stopped
         // before calling it. But this creates issues on Camera2 Legacy devices - they need a

--- a/docs/_docs/capturing-media.md
+++ b/docs/_docs/capturing-media.md
@@ -102,7 +102,9 @@ camera.addCameraListener(new CameraListener() {
 |`isTakingPicture()`|Returns true if the camera is currently capturing a picture.|
 |`takePicture()`|Takes a high quality picture.|
 |`takeVideo(File)`|Takes a high quality video.|
+|`takeVideo(FileDescriptor)`|Takes a high quality video.|
 |`takeVideo(File, long)`|Takes a high quality video, stopping after the given duration.|
+|`takeVideo(FileDescriptor, long)`|Takes a high quality video, stopping after the given duration.|
 |`takePictureSnapshot()`|Takes a picture snapshot.|
 |`takeVideoSnapshot(File)`|Takes a video snapshot.|
 |`takeVideoSnapshot(File, long)`|Takes a video snapshot, stopping after the given duration.|


### PR DESCRIPTION
Added support to save video recording to FileDescriptor using takeVideo(). Didn't update takeVideoSnapshot() since it uses MediaMuxer which has support for FileDescriptor from [API 26 only](https://developer.android.com/reference/android/media/MediaMuxer#MediaMuxer(java.io.FileDescriptor,%20int)).

- Fixes #461
- Tests: no
- Docs updated: yes
