### PR TITLE
Switch mode without restart

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -870,6 +870,11 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         mExperimental = experimental;
     }
 
+    /**
+     * Sets the flag if you want disable restart camera on change mode (Photo/Video),
+     * but only for {@link Engine#CAMERA1}
+     * @param changeModeWithoutRestart - true if you want disable restart
+     */
     public void setChangeModeWithoutRestart(boolean changeModeWithoutRestart) {
         mChangeModeWithoutRestart = changeModeWithoutRestart;
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -159,6 +159,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private boolean mExperimental;
     private boolean mInEditor;
+    private boolean mChangeModeWithoutRestart;
 
     // Overlays
     @VisibleForTesting OverlayLayout mOverlayLayout;
@@ -869,6 +870,10 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         mExperimental = experimental;
     }
 
+    public void setChangeModeWithoutRestart(boolean changeModeWithoutRestart) {
+        mChangeModeWithoutRestart = changeModeWithoutRestart;
+    }
+
     /**
      * Shorthand for the appropriate set* method.
      * For example, if control is a {@link Grid}, this calls {@link #setGrid(Grid)}.
@@ -1420,7 +1425,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
      * @param mode desired session type.
      */
     public void setMode(@NonNull Mode mode) {
-        mCameraEngine.setMode(mode);
+        mCameraEngine.setMode(mode, mChangeModeWithoutRestart);
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
@@ -145,6 +145,28 @@ public class Camera1Engine extends CameraBaseEngine implements
         return false;
     }
 
+    @EngineThread
+    @Override
+    protected void prepareNewMode() {
+        mCaptureSize = computeCaptureSize();
+        Camera.Parameters params = mCamera.getParameters();
+        if (getMode() == Mode.PICTURE) {
+            // setPictureSize is allowed during preview
+            params.setPictureSize(mCaptureSize.getWidth(), mCaptureSize.getHeight());
+        } else {
+            // mCaptureSize in this case is a video size. The available video sizes are not
+            // necessarily a subset of the picture sizes, so we can't use the mCaptureSize value:
+            // it might crash. However, the setPictureSize() passed here is useless : we don't allow
+            // HQ pictures in video mode.
+            // While this might be lifted in the future, for now, just use a picture capture size.
+            Size pictureSize = computeCaptureSize(Mode.PICTURE);
+            params.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
+        }
+        applyDefaultFocus(params);
+        params.setRecordingHint(getMode() == Mode.VIDEO);
+        mCamera.setParameters(params);
+    }
+
     //endregion
 
     //region Start

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
@@ -150,18 +150,7 @@ public class Camera1Engine extends CameraBaseEngine implements
     protected void prepareNewMode() {
         mCaptureSize = computeCaptureSize();
         Camera.Parameters params = mCamera.getParameters();
-        if (getMode() == Mode.PICTURE) {
-            // setPictureSize is allowed during preview
-            params.setPictureSize(mCaptureSize.getWidth(), mCaptureSize.getHeight());
-        } else {
-            // mCaptureSize in this case is a video size. The available video sizes are not
-            // necessarily a subset of the picture sizes, so we can't use the mCaptureSize value:
-            // it might crash. However, the setPictureSize() passed here is useless : we don't allow
-            // HQ pictures in video mode.
-            // While this might be lifted in the future, for now, just use a picture capture size.
-            Size pictureSize = computeCaptureSize(Mode.PICTURE);
-            params.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
-        }
+        setPictureSize(params);
         applyDefaultFocus(params);
         params.setRecordingHint(getMode() == Mode.VIDEO);
         mCamera.setParameters(params);
@@ -238,18 +227,7 @@ public class Camera1Engine extends CameraBaseEngine implements
         params.setPreviewFormat(ImageFormat.NV21);
         // setPreviewSize is not allowed during preview
         params.setPreviewSize(mPreviewStreamSize.getWidth(), mPreviewStreamSize.getHeight());
-        if (getMode() == Mode.PICTURE) {
-            // setPictureSize is allowed during preview
-            params.setPictureSize(mCaptureSize.getWidth(), mCaptureSize.getHeight());
-        } else {
-            // mCaptureSize in this case is a video size. The available video sizes are not
-            // necessarily a subset of the picture sizes, so we can't use the mCaptureSize value:
-            // it might crash. However, the setPictureSize() passed here is useless : we don't allow
-            // HQ pictures in video mode.
-            // While this might be lifted in the future, for now, just use a picture capture size.
-            Size pictureSize = computeCaptureSize(Mode.PICTURE);
-            params.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
-        }
+        setPictureSize(params);
         mCamera.setParameters(params);
 
         mCamera.setPreviewCallbackWithBuffer(null); // Release anything left

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera2Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera2Engine.java
@@ -389,6 +389,13 @@ public class Camera2Engine extends CameraBaseEngine implements
         return false;
     }
 
+    @EngineThread
+    @Override
+    protected void prepareNewMode() {
+        LOG.w("prepareNewMode:", "can't prepare new mode without restart for Engine2");
+        restart();
+    }
+
     //endregion
 
     //region Start

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -2,6 +2,7 @@ package com.otaliastudios.cameraview.engine;
 
 import android.graphics.PointF;
 import android.graphics.RectF;
+import android.hardware.Camera;
 import android.location.Location;
 
 import androidx.annotation.CallSuper;
@@ -754,6 +755,21 @@ public abstract class CameraBaseEngine extends CameraEngine {
         if (preview == null) return null;
         return getAngles().flip(Reference.VIEW, reference) ? preview.getSurfaceSize().flip()
                 : preview.getSurfaceSize();
+    }
+
+    void setPictureSize(Camera.Parameters params) {
+        if (getMode() == Mode.PICTURE) {
+            // setPictureSize is allowed during preview
+            params.setPictureSize(mCaptureSize.getWidth(), mCaptureSize.getHeight());
+        } else {
+            // mCaptureSize in this case is a video size. The available video sizes are not
+            // necessarily a subset of the picture sizes, so we can't use the mCaptureSize value:
+            // it might crash. However, the setPictureSize() passed here is useless : we don't allow
+            // HQ pictures in video mode.
+            // While this might be lifted in the future, for now, just use a picture capture size.
+            Size pictureSize = computeCaptureSize(Mode.PICTURE);
+            params.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
+        }
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -383,18 +383,24 @@ public abstract class CameraBaseEngine extends CameraEngine {
      * @param mode desired mode.
      */
     @Override
-    public final void setMode(@NonNull Mode mode) {
+    public final void setMode(@NonNull Mode mode, final boolean withoutRestart) {
         if (mode != mMode) {
             mMode = mode;
             getOrchestrator().scheduleStateful("mode", CameraState.ENGINE,
                     new Runnable() {
                 @Override
                 public void run() {
-                    restart();
+                    if (withoutRestart) {
+                        prepareNewMode();
+                    } else {
+                        restart();
+                    }
                 }
             });
         }
     }
+
+    protected abstract void prepareNewMode();
 
     @NonNull
     @Override

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -664,7 +664,7 @@ public abstract class CameraEngine implements
     public abstract void setAudio(@NonNull Audio audio);
     @NonNull public abstract Audio getAudio();
 
-    public abstract void setMode(@NonNull Mode mode);
+    public abstract void setMode(@NonNull Mode mode, boolean withoutRestart);
     @NonNull public abstract Mode getMode();
 
     public abstract void setZoom(float zoom, @Nullable PointF[] points, boolean notify);


### PR DESCRIPTION
- Fixes #805
- Tests: no
- Docs updated: no

### Solution
I trying use all actions, which depend on Mode (photo/video), without restart camera (preview, engine), but only for Engine.Camera1. I added flag for this small improve.
