### PR TITLE
Add capability to set audio codec to encode video files with.

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
@@ -19,6 +19,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.ControlParser;
 import com.otaliastudios.cameraview.controls.Engine;
 import com.otaliastudios.cameraview.controls.Facing;
@@ -165,6 +166,7 @@ public class CameraViewTest extends BaseTest {
         assertEquals(cameraView.getHdr(), controls.getHdr());
         assertEquals(cameraView.getAudio(), controls.getAudio());
         assertEquals(cameraView.getVideoCodec(), controls.getVideoCodec());
+        assertEquals(cameraView.getAudioCodec(), controls.getAudioCodec());
         assertEquals(cameraView.getPictureFormat(), controls.getPictureFormat());
         //noinspection SimplifiableJUnitAssertion
         assertEquals(cameraView.getLocation(), null);
@@ -772,6 +774,25 @@ public class CameraViewTest extends BaseTest {
         cameraView.set(Audio.STEREO);
         assertEquals(cameraView.get(Audio.class), Audio.STEREO);
     }
+
+    @Test
+    public void testAudioCodec() {
+        cameraView.set(AudioCodec.DEVICE_DEFAULT);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.DEVICE_DEFAULT);
+        cameraView.set(AudioCodec.AMR_NB);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AMR_NB);
+        cameraView.set(AudioCodec.AMR_WB);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AMR_WB);
+        cameraView.set(AudioCodec.AAC);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AAC);
+        cameraView.set(AudioCodec.HE_AAC);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.HE_AAC);
+        cameraView.set(AudioCodec.AAC_ELD);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AAC_ELD);
+        cameraView.set(AudioCodec.VORBIS);
+        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.VORBIS);
+    }
+
 
     @Test
     public void testVideoCodec() {

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/CameraViewTest.java
@@ -779,18 +779,12 @@ public class CameraViewTest extends BaseTest {
     public void testAudioCodec() {
         cameraView.set(AudioCodec.DEVICE_DEFAULT);
         assertEquals(cameraView.get(AudioCodec.class), AudioCodec.DEVICE_DEFAULT);
-        cameraView.set(AudioCodec.AMR_NB);
-        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AMR_NB);
-        cameraView.set(AudioCodec.AMR_WB);
-        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AMR_WB);
         cameraView.set(AudioCodec.AAC);
         assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AAC);
         cameraView.set(AudioCodec.HE_AAC);
         assertEquals(cameraView.get(AudioCodec.class), AudioCodec.HE_AAC);
         cameraView.set(AudioCodec.AAC_ELD);
         assertEquals(cameraView.get(AudioCodec.class), AudioCodec.AAC_ELD);
-        cameraView.set(AudioCodec.VORBIS);
-        assertEquals(cameraView.get(AudioCodec.class), AudioCodec.VORBIS);
     }
 
 

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/VideoResultTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/VideoResultTest.java
@@ -4,6 +4,7 @@ package com.otaliastudios.cameraview;
 import android.location.Location;
 
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Facing;
 import com.otaliastudios.cameraview.controls.VideoCodec;
 import com.otaliastudios.cameraview.size.Size;
@@ -32,7 +33,8 @@ public class VideoResultTest extends BaseTest {
         File file = Mockito.mock(File.class);
         int rotation = 90;
         Size size = new Size(20, 120);
-        VideoCodec codec = VideoCodec.H_263;
+        VideoCodec videoCodec = VideoCodec.H_263;
+        AudioCodec audioCodec = AudioCodec.DEVICE_DEFAULT;
         Location location = Mockito.mock(Location.class);
         boolean isSnapshot = true;
         int maxDuration = 1234;
@@ -47,7 +49,8 @@ public class VideoResultTest extends BaseTest {
         stub.file = file;
         stub.rotation = rotation;
         stub.size = size;
-        stub.videoCodec = codec;
+        stub.videoCodec = videoCodec;
+        stub.audioCodec = audioCodec;
         stub.location = location;
         stub.isSnapshot = isSnapshot;
         stub.maxDuration = maxDuration;
@@ -63,7 +66,8 @@ public class VideoResultTest extends BaseTest {
         assertEquals(result.getFile(), file);
         assertEquals(result.getRotation(), rotation);
         assertEquals(result.getSize(), size);
-        assertEquals(result.getVideoCodec(), codec);
+        assertEquals(result.getVideoCodec(), videoCodec);
+        assertEquals(result.getAudioCodec(), audioCodec);
         assertEquals(result.getLocation(), location);
         assertEquals(result.isSnapshot(), isSnapshot);
         assertEquals(result.getMaxSize(), maxFileSize);
@@ -81,7 +85,8 @@ public class VideoResultTest extends BaseTest {
         FileDescriptor fileDescriptor = FileDescriptor.in;
         int rotation = 90;
         Size size = new Size(20, 120);
-        VideoCodec codec = VideoCodec.H_263;
+        VideoCodec videoCodec = VideoCodec.H_263;
+        AudioCodec audioCodec = AudioCodec.DEVICE_DEFAULT;
         Location location = Mockito.mock(Location.class);
         boolean isSnapshot = true;
         int maxDuration = 1234;
@@ -96,7 +101,8 @@ public class VideoResultTest extends BaseTest {
         stub.fileDescriptor = fileDescriptor;
         stub.rotation = rotation;
         stub.size = size;
-        stub.videoCodec = codec;
+        stub.videoCodec = videoCodec;
+        stub.audioCodec = audioCodec;
         stub.location = location;
         stub.isSnapshot = isSnapshot;
         stub.maxDuration = maxDuration;
@@ -112,7 +118,8 @@ public class VideoResultTest extends BaseTest {
         assertEquals(result.getFileDescriptor(), fileDescriptor);
         assertEquals(result.getRotation(), rotation);
         assertEquals(result.getSize(), size);
-        assertEquals(result.getVideoCodec(), codec);
+        assertEquals(result.getVideoCodec(), videoCodec);
+        assertEquals(result.getAudioCodec(), audioCodec);
         assertEquals(result.getLocation(), location);
         assertEquals(result.isSnapshot(), isSnapshot);
         assertEquals(result.getMaxSize(), maxFileSize);

--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/engine/options/Camera1OptionsTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/engine/options/Camera1OptionsTest.java
@@ -7,6 +7,7 @@ import android.hardware.Camera;
 import com.otaliastudios.cameraview.BaseTest;
 import com.otaliastudios.cameraview.CameraOptions;
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Facing;
 import com.otaliastudios.cameraview.controls.Flash;
 import com.otaliastudios.cameraview.controls.PictureFormat;
@@ -244,10 +245,12 @@ public class Camera1OptionsTest extends BaseTest {
 
         Collection<Grid> grids = o.getSupportedControls(Grid.class);
         Collection<VideoCodec> video = o.getSupportedControls(VideoCodec.class);
+        Collection<AudioCodec> audioCodecs = o.getSupportedControls(AudioCodec.class);
         Collection<Mode> sessions = o.getSupportedControls(Mode.class);
         Collection<Audio> audio = o.getSupportedControls(Audio.class);
         assertEquals(grids.size(), Grid.values().length);
         assertEquals(video.size(), VideoCodec.values().length);
+        assertEquals(audioCodecs.size(), AudioCodec.values().length);
         assertEquals(sessions.size(), Mode.values().length);
         assertEquals(audio.size(), Audio.values().length);
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraOptions.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraOptions.java
@@ -4,6 +4,7 @@ package com.otaliastudios.cameraview;
 import android.graphics.ImageFormat;
 
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Control;
 import com.otaliastudios.cameraview.controls.Engine;
 import com.otaliastudios.cameraview.controls.Facing;
@@ -105,6 +106,8 @@ public abstract class CameraOptions {
             return (Collection<T>) Arrays.asList(Mode.values());
         } else if (controlClass.equals(VideoCodec.class)) {
             return (Collection<T>) Arrays.asList(VideoCodec.values());
+        } else if (controlClass.equals(AudioCodec.class)) {
+            return (Collection<T>) Arrays.asList(AudioCodec.values());
         } else if (controlClass.equals(WhiteBalance.class)) {
             return (Collection<T>) getSupportedWhiteBalance();
         } else if (controlClass.equals(Engine.class)) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1655,12 +1655,9 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
      * Defaults to {@link AudioCodec#DEVICE_DEFAULT}.
      *
      * @see AudioCodec#DEVICE_DEFAULT
-     * @see AudioCodec#AMR_NB
-     * @see AudioCodec#AMR_WB
      * @see AudioCodec#AAC
      * @see AudioCodec#HE_AAC
      * @see AudioCodec#AAC_ELD
-     * @see AudioCodec#VORBIS
      *
      * @param codec requested audio codec
      */

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -33,6 +33,7 @@ import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.OnLifecycleEvent;
 
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Control;
 import com.otaliastudios.cameraview.controls.ControlParser;
 import com.otaliastudios.cameraview.controls.Engine;
@@ -268,6 +269,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         setHdr(controls.getHdr());
         setAudio(controls.getAudio());
         setAudioBitRate(audioBitRate);
+        setAudioCodec(controls.getAudioCodec());
         setPictureSize(sizeSelectors.getPictureSizeSelector());
         setPictureMetering(pictureMetering);
         setPictureSnapshotMetering(pictureSnapshotMetering);
@@ -906,6 +908,8 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
             setWhiteBalance((WhiteBalance) control);
         } else if (control instanceof VideoCodec) {
             setVideoCodec((VideoCodec) control);
+        } else if (control instanceof AudioCodec) {
+            setAudioCodec((AudioCodec) control);
         } else if (control instanceof Preview) {
             setPreview((Preview) control);
         } else if (control instanceof Engine) {
@@ -942,6 +946,8 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
             return (T) getWhiteBalance();
         } else if (controlClass == VideoCodec.class) {
             return (T) getVideoCodec();
+        } else if (controlClass == AudioCodec.class) {
+            return (T) getAudioCodec();
         } else if (controlClass == Preview.class) {
             return (T) getPreview();
         } else if (controlClass == Engine.class) {
@@ -1014,6 +1020,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         setHdr(oldEngine.getHdr());
         setAudio(oldEngine.getAudio());
         setAudioBitRate(oldEngine.getAudioBitRate());
+        setAudioCodec(oldEngine.getAudioCodec());
         setPictureSize(oldEngine.getPictureSizeSelector());
         setPictureFormat(oldEngine.getPictureFormat());
         setVideoSize(oldEngine.getVideoSizeSelector());
@@ -1641,6 +1648,33 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @SuppressWarnings("unused")
     public int getAudioBitRate() {
         return mCameraEngine.getAudioBitRate();
+    }
+
+    /**
+     * Sets the encoder for audio recordings.
+     * Defaults to {@link AudioCodec#DEVICE_DEFAULT}.
+     *
+     * @see AudioCodec#DEVICE_DEFAULT
+     * @see AudioCodec#AMR_NB
+     * @see AudioCodec#AMR_WB
+     * @see AudioCodec#AAC
+     * @see AudioCodec#HE_AAC
+     * @see AudioCodec#AAC_ELD
+     * @see AudioCodec#VORBIS
+     *
+     * @param codec requested audio codec
+     */
+    public void setAudioCodec(@NonNull AudioCodec codec) {
+        mCameraEngine.setAudioCodec(codec);
+    }
+
+    /**
+     * Gets the current encoder for audio recordings.
+     * @return the current audio codec
+     */
+    @NonNull
+    public AudioCodec getAudioCodec() {
+        return mCameraEngine.getAudioCodec();
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
@@ -3,6 +3,7 @@ package com.otaliastudios.cameraview;
 import android.location.Location;
 
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Facing;
 import com.otaliastudios.cameraview.controls.VideoCodec;
 import com.otaliastudios.cameraview.size.Size;
@@ -34,6 +35,7 @@ public class VideoResult {
         public FileDescriptor fileDescriptor;
         public Facing facing;
         public VideoCodec videoCodec;
+        public AudioCodec audioCodec;
         public Audio audio;
         public long maxSize;
         public int maxDuration;
@@ -60,6 +62,7 @@ public class VideoResult {
     private final FileDescriptor fileDescriptor;
     private final Facing facing;
     private final VideoCodec videoCodec;
+    private final AudioCodec audioCodec;
     private final Audio audio;
     private final long maxSize;
     private final int maxDuration;
@@ -77,6 +80,7 @@ public class VideoResult {
         fileDescriptor = builder.fileDescriptor;
         facing = builder.facing;
         videoCodec = builder.videoCodec;
+        audioCodec = builder.audioCodec;
         audio = builder.audio;
         maxSize = builder.maxSize;
         maxDuration = builder.maxDuration;
@@ -171,6 +175,16 @@ public class VideoResult {
     @NonNull
     public VideoCodec getVideoCodec() {
         return videoCodec;
+    }
+
+    /**
+     * Returns the codec that was used to encode the audio frames.
+     *
+     * @return the audio codec
+     */
+    @NonNull
+    public AudioCodec getAudioCodec() {
+        return audioCodec;
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/controls/AudioCodec.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/controls/AudioCodec.java
@@ -1,0 +1,79 @@
+package com.otaliastudios.cameraview.controls;
+
+
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import com.otaliastudios.cameraview.CameraView;
+
+/**
+ * Constants for selecting the encoder of audio recordings.
+ * https://developer.android.com/guide/topics/media/media-formats.html#audio-formats
+ *
+ * @see CameraView#setAudioCodec(AudioCodec)
+ */
+public enum AudioCodec implements Control {
+
+    /**
+     * Let the device choose its codec.
+     */
+    DEVICE_DEFAULT(0),
+
+    /**
+     * The AMR_NB codec.
+     */
+    AMR_NB(1),
+
+    /**
+     * The AMR_WB codec.
+     */
+    AMR_WB(2),
+
+    /**
+     * The AAC codec.
+     */
+    AAC(3),
+
+    /**
+     * The HE_AAC codec.
+     */
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
+    HE_AAC(4),
+
+    /**
+     * The AAC_ELD codec.
+     */
+    @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
+    AAC_ELD(5),
+
+    /**
+     * The VORBIS codec.
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    VORBIS(6);
+
+    static final AudioCodec DEFAULT = DEVICE_DEFAULT;
+
+    private int value;
+
+    AudioCodec(int value) {
+        this.value = value;
+    }
+
+    int value() {
+        return value;
+    }
+
+    @NonNull
+    static AudioCodec fromValue(int value) {
+        AudioCodec[] list = AudioCodec.values();
+        for (AudioCodec action : list) {
+            if (action.value() == value) {
+                return action;
+            }
+        }
+        return DEFAULT;
+    }
+}

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/controls/AudioCodec.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/controls/AudioCodec.java
@@ -22,37 +22,21 @@ public enum AudioCodec implements Control {
     DEVICE_DEFAULT(0),
 
     /**
-     * The AMR_NB codec.
-     */
-    AMR_NB(1),
-
-    /**
-     * The AMR_WB codec.
-     */
-    AMR_WB(2),
-
-    /**
      * The AAC codec.
      */
-    AAC(3),
+    AAC(1),
 
     /**
      * The HE_AAC codec.
      */
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
-    HE_AAC(4),
+    HE_AAC(2),
 
     /**
      * The AAC_ELD codec.
      */
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
-    AAC_ELD(5),
-
-    /**
-     * The VORBIS codec.
-     */
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    VORBIS(6);
+    AAC_ELD(3);
 
     static final AudioCodec DEFAULT = DEVICE_DEFAULT;
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/controls/ControlParser.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/controls/ControlParser.java
@@ -22,6 +22,7 @@ public class ControlParser {
     private int hdr;
     private int audio;
     private int videoCodec;
+    private int audioCodec;
     private int engine;
     private int pictureFormat;
 
@@ -38,6 +39,8 @@ public class ControlParser {
         audio = array.getInteger(R.styleable.CameraView_cameraAudio, Audio.DEFAULT.value());
         videoCodec = array.getInteger(R.styleable.CameraView_cameraVideoCodec,
                 VideoCodec.DEFAULT.value());
+        audioCodec = array.getInteger(R.styleable.CameraView_cameraAudioCodec,
+                AudioCodec.DEFAULT.value());
         engine = array.getInteger(R.styleable.CameraView_cameraEngine, Engine.DEFAULT.value());
         pictureFormat = array.getInteger(R.styleable.CameraView_cameraPictureFormat,
                 PictureFormat.DEFAULT.value());
@@ -82,6 +85,11 @@ public class ControlParser {
     @NonNull
     public Audio getAudio() {
         return Audio.fromValue(audio);
+    }
+
+    @NonNull
+    public AudioCodec getAudioCodec() {
+        return AudioCodec.fromValue(audioCodec);
     }
 
     @NonNull

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -16,6 +16,7 @@ import com.otaliastudios.cameraview.CameraOptions;
 import com.otaliastudios.cameraview.PictureResult;
 import com.otaliastudios.cameraview.VideoResult;
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.Facing;
 import com.otaliastudios.cameraview.controls.Flash;
 import com.otaliastudios.cameraview.controls.Hdr;
@@ -61,6 +62,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
     @SuppressWarnings("WeakerAccess") protected Flash mFlash;
     @SuppressWarnings("WeakerAccess") protected WhiteBalance mWhiteBalance;
     @SuppressWarnings("WeakerAccess") protected VideoCodec mVideoCodec;
+    @SuppressWarnings("WeakerAccess") protected AudioCodec mAudioCodec;
     @SuppressWarnings("WeakerAccess") protected Hdr mHdr;
     @SuppressWarnings("WeakerAccess") protected PictureFormat mPictureFormat;
     @SuppressWarnings("WeakerAccess") protected Location mLocation;
@@ -241,6 +243,17 @@ public abstract class CameraBaseEngine extends CameraEngine {
     @Override
     public final int getVideoBitRate() {
         return mVideoBitRate;
+    }
+
+    @Override
+    public final void setAudioCodec(@NonNull AudioCodec codec) {
+        mAudioCodec = codec;
+    }
+
+    @NonNull
+    @Override
+    public final AudioCodec getAudioCodec() {
+        return mAudioCodec;
     }
 
     @Override
@@ -581,6 +594,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
                 }
                 stub.isSnapshot = false;
                 stub.videoCodec = mVideoCodec;
+                stub.audioCodec = mAudioCodec;
                 stub.location = mLocation;
                 stub.facing = mFacing;
                 stub.audio = mAudio;
@@ -608,6 +622,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
                 stub.file = file;
                 stub.isSnapshot = true;
                 stub.videoCodec = mVideoCodec;
+                stub.audioCodec = mAudioCodec;
                 stub.location = mLocation;
                 stub.facing = mFacing;
                 stub.videoBitRate = mVideoBitRate;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -17,6 +17,7 @@ import com.otaliastudios.cameraview.CameraException;
 import com.otaliastudios.cameraview.CameraLogger;
 import com.otaliastudios.cameraview.CameraOptions;
 import com.otaliastudios.cameraview.PictureResult;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.PictureFormat;
 import com.otaliastudios.cameraview.engine.orchestrator.CameraOrchestrator;
 import com.otaliastudios.cameraview.engine.orchestrator.CameraState;
@@ -636,6 +637,9 @@ public abstract class CameraEngine implements
 
     public abstract void setAudioBitRate(int audioBitRate);
     public abstract int getAudioBitRate();
+
+    public abstract void setAudioCodec(@NonNull AudioCodec codec);
+    @NonNull public abstract AudioCodec getAudioCodec();
 
     public abstract void setSnapshotMaxWidth(int maxWidth);
     public abstract int getSnapshotMaxWidth();

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -108,7 +108,6 @@ public abstract class FullVideoRecorder extends VideoRecorder {
             mProfile.videoCodec = MediaRecorder.VideoEncoder.H263;
             mProfile.fileFormat = MediaRecorder.OutputFormat.MPEG_4; // should work
         }
-        mMediaRecorder.setOutputFormat(mProfile.fileFormat);
         // Set audio codec if the user has specified a specific codec.
         if (stub.audioCodec == AudioCodec.AMR_NB) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_NB;
@@ -126,6 +125,7 @@ public abstract class FullVideoRecorder extends VideoRecorder {
                 && stub.audioCodec == AudioCodec.VORBIS) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.VORBIS;
         }
+        mMediaRecorder.setOutputFormat(mProfile.fileFormat);
 
         // 4. Update the VideoResult stub with information from the profile, if the
         // stub values are absent or incomplete

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -109,11 +109,7 @@ public abstract class FullVideoRecorder extends VideoRecorder {
             mProfile.fileFormat = MediaRecorder.OutputFormat.MPEG_4; // should work
         }
         // Set audio codec if the user has specified a specific codec.
-        if (stub.audioCodec == AudioCodec.AMR_NB) {
-            mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_NB;
-        } else if (stub.audioCodec == AudioCodec.AMR_WB) {
-            mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_WB;
-        } else if (stub.audioCodec == AudioCodec.AAC) {
+        if (stub.audioCodec == AudioCodec.AAC) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC;
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
                 && stub.audioCodec == AudioCodec.HE_AAC) {
@@ -121,9 +117,6 @@ public abstract class FullVideoRecorder extends VideoRecorder {
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
                 && stub.audioCodec == AudioCodec.AAC_ELD) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC_ELD;
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                && stub.audioCodec == AudioCodec.VORBIS) {
-            mProfile.audioCodec = MediaRecorder.AudioEncoder.VORBIS;
         }
         mMediaRecorder.setOutputFormat(mProfile.fileFormat);
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -116,11 +116,14 @@ public abstract class FullVideoRecorder extends VideoRecorder {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_WB;
         } else if (stub.audioCodec == AudioCodec.AAC) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC;
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && stub.audioCodec == AudioCodec.HE_AAC) {
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && stub.audioCodec == AudioCodec.HE_AAC) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.HE_AAC;
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&stub.audioCodec == AudioCodec.AAC_ELD) {
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && stub.audioCodec == AudioCodec.AAC_ELD) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC_ELD;
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && stub.audioCodec == AudioCodec.VORBIS) {
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                && stub.audioCodec == AudioCodec.VORBIS) {
             mProfile.audioCodec = MediaRecorder.AudioEncoder.VORBIS;
         }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -2,10 +2,12 @@ package com.otaliastudios.cameraview.video;
 
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
+import android.os.Build;
 
 import com.otaliastudios.cameraview.CameraLogger;
 import com.otaliastudios.cameraview.VideoResult;
 import com.otaliastudios.cameraview.controls.Audio;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.controls.VideoCodec;
 import com.otaliastudios.cameraview.internal.DeviceEncoders;
 import com.otaliastudios.cameraview.internal.CamcorderProfiles;
@@ -13,6 +15,7 @@ import com.otaliastudios.cameraview.size.Size;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 /**
  * A {@link VideoRecorder} that uses {@link android.media.MediaRecorder} APIs.
@@ -106,6 +109,20 @@ public abstract class FullVideoRecorder extends VideoRecorder {
             mProfile.fileFormat = MediaRecorder.OutputFormat.MPEG_4; // should work
         }
         mMediaRecorder.setOutputFormat(mProfile.fileFormat);
+        // Set audio codec if the user has specified a specific codec.
+        if (stub.audioCodec == AudioCodec.AMR_NB) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_NB;
+        } else if (stub.audioCodec == AudioCodec.AMR_WB) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.AMR_WB;
+        } else if (stub.audioCodec == AudioCodec.AAC) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && stub.audioCodec == AudioCodec.HE_AAC) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.HE_AAC;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&stub.audioCodec == AudioCodec.AAC_ELD) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.AAC_ELD;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && stub.audioCodec == AudioCodec.VORBIS) {
+            mProfile.audioCodec = MediaRecorder.AudioEncoder.VORBIS;
+        }
 
         // 4. Update the VideoResult stub with information from the profile, if the
         // stub values are absent or incomplete

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -148,9 +148,8 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
                 case AAC:
                 case HE_AAC:
                 case AAC_ELD:
-                    audioType = "audio/mp4a-latm"; break;
                 case DEVICE_DEFAULT:
-                    audioType = "audio/3gpp";
+                    audioType = "audio/mp4a-latm"; break;
             }
             TextureConfig videoConfig = new TextureConfig();
             AudioConfig audioConfig = new AudioConfig();

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -1,10 +1,12 @@
 package com.otaliastudios.cameraview.video;
 
 import android.graphics.SurfaceTexture;
+import android.media.MediaRecorder;
 import android.opengl.EGL14;
 import android.os.Build;
 
 import com.otaliastudios.cameraview.CameraLogger;
+import com.otaliastudios.cameraview.controls.AudioCodec;
 import com.otaliastudios.cameraview.internal.DeviceEncoders;
 import com.otaliastudios.cameraview.overlay.Overlay;
 import com.otaliastudios.cameraview.VideoResult;
@@ -141,7 +143,20 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
                 case H_264: videoType = "video/avc"; break; // MediaFormat.MIMETYPE_VIDEO_AVC:
                 case DEVICE_DEFAULT: videoType = "video/avc"; break;
             }
-            String audioType = "audio/mp4a-latm";
+            String audioType = "";
+            if (mResult.audioCodec == AudioCodec.AMR_NB) {
+                audioType = "audio/3gpp";
+            } else if (mResult.audioCodec == AudioCodec.AMR_WB) {
+                audioType = "audio/amr-wb";
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                    && mResult.audioCodec == AudioCodec.VORBIS) {
+                audioType = "audio/vorbis";
+            } else if (mResult.audioCodec == AudioCodec.AAC
+                    || mResult.audioCodec == AudioCodec.HE_AAC
+                    || mResult.audioCodec == AudioCodec.AAC_ELD
+                    || mResult.audioCodec == AudioCodec.DEVICE_DEFAULT) {
+                audioType = "audio/mp4a-latm";
+            }
             TextureConfig videoConfig = new TextureConfig();
             AudioConfig audioConfig = new AudioConfig();
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -144,18 +144,13 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
                 case DEVICE_DEFAULT: videoType = "video/avc"; break;
             }
             String audioType = "";
-            if (mResult.audioCodec == AudioCodec.AMR_NB) {
-                audioType = "audio/3gpp";
-            } else if (mResult.audioCodec == AudioCodec.AMR_WB) {
-                audioType = "audio/amr-wb";
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-                    && mResult.audioCodec == AudioCodec.VORBIS) {
-                audioType = "audio/vorbis";
-            } else if (mResult.audioCodec == AudioCodec.AAC
-                    || mResult.audioCodec == AudioCodec.HE_AAC
-                    || mResult.audioCodec == AudioCodec.AAC_ELD
-                    || mResult.audioCodec == AudioCodec.DEVICE_DEFAULT) {
-                audioType = "audio/mp4a-latm";
+            switch (mResult.audioCodec) {
+                case AAC:
+                case HE_AAC:
+                case AAC_ELD:
+                    audioType = "audio/mp4a-latm"; break;
+                case DEVICE_DEFAULT:
+                    audioType = "audio/3gpp";
             }
             TextureConfig videoConfig = new TextureConfig();
             AudioConfig audioConfig = new AudioConfig();

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -1,6 +1,7 @@
 package com.otaliastudios.cameraview.video;
 
 import android.graphics.SurfaceTexture;
+import android.media.MediaFormat;
 import android.media.MediaRecorder;
 import android.opengl.EGL14;
 import android.os.Build;
@@ -147,9 +148,9 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
             switch (mResult.audioCodec) {
                 case AAC:
                 case HE_AAC:
-                case AAC_ELD:
-                case DEVICE_DEFAULT:
-                    audioType = "audio/mp4a-latm"; break;
+                case AAC_ELD: audioType = "audio/mp4a-latm"; break; // MediaFormat.MIMETYPE_AUDIO_AAC:
+                case DEVICE_DEFAULT: audioType = "audio/mp4a-latm"; break;
+
             }
             TextureConfig videoConfig = new TextureConfig();
             AudioConfig audioConfig = new AudioConfig();

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -143,12 +143,9 @@
 
         <attr name="cameraAudioCodec" format="enum">
             <enum name="deviceDefault" value="0" />
-            <enum name="amrNb" value="1" />
-            <enum name="amrWb" value="2" />
-            <enum name="aac" value="3" />
-            <enum name="heAac" value="4" />
-            <enum name="aacEld" value="5" />
-            <enum name="vorbis" value="6" />
+            <enum name="aac" value="1" />
+            <enum name="heAac" value="2" />
+            <enum name="aacEld" value="3" />
         </attr>
 
         <attr name="cameraAutoFocusResetDelay" format="integer|reference"/>

--- a/cameraview/src/main/res/values/attrs.xml
+++ b/cameraview/src/main/res/values/attrs.xml
@@ -141,6 +141,16 @@
             <enum name="h264" value="2" />
         </attr>
 
+        <attr name="cameraAudioCodec" format="enum">
+            <enum name="deviceDefault" value="0" />
+            <enum name="amrNb" value="1" />
+            <enum name="amrWb" value="2" />
+            <enum name="aac" value="3" />
+            <enum name="heAac" value="4" />
+            <enum name="aacEld" value="5" />
+            <enum name="vorbis" value="6" />
+        </attr>
+
         <attr name="cameraAutoFocusResetDelay" format="integer|reference"/>
 
         <attr name="cameraAutoFocusMarker" format="string|reference"/>

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/CameraActivity.java
@@ -123,7 +123,7 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
                 new Option.PictureMetering(), new Option.PictureSnapshotMetering(),
                 new Option.PictureFormat(),
                 // Video recording
-                new Option.PreviewFrameRate(), new Option.VideoCodec(), new Option.Audio(),
+                new Option.PreviewFrameRate(), new Option.VideoCodec(), new Option.Audio(), new Option.AudioCodec(),
                 // Gestures
                 new Option.Pinch(), new Option.HorizontalScroll(), new Option.VerticalScroll(),
                 new Option.Tap(), new Option.LongTap(),
@@ -144,7 +144,7 @@ public class CameraActivity extends AppCompatActivity implements View.OnClickLis
                 // Some controls
                 false, false, false, false, false, true,
                 // Video recording
-                false, false, true,
+                false, false, false, true,
                 // Gestures
                 false, false, false, false, true,
                 // Watermarks

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/Option.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/Option.java
@@ -308,6 +308,12 @@ public abstract class Option<T> {
         }
     }
 
+    public static class AudioCodec extends ControlOption<com.otaliastudios.cameraview.controls.AudioCodec> {
+        public AudioCodec() {
+            super(com.otaliastudios.cameraview.controls.AudioCodec.class, "Audio Codec");
+        }
+    }
+
     public static class Audio extends ControlOption<com.otaliastudios.cameraview.controls.Audio> {
         public Audio() {
             super(com.otaliastudios.cameraview.controls.Audio.class, "Audio");

--- a/demo/src/main/java/com/otaliastudios/cameraview/demo/VideoPreviewActivity.java
+++ b/demo/src/main/java/com/otaliastudios/cameraview/demo/VideoPreviewActivity.java
@@ -59,6 +59,7 @@ public class VideoPreviewActivity extends AppCompatActivity {
         final MessageView audio = findViewById(R.id.audio);
         final MessageView audioBitRate = findViewById(R.id.audioBitRate);
         final MessageView videoCodec = findViewById(R.id.videoCodec);
+        final MessageView audioCodec = findViewById(R.id.audioCodec);
         final MessageView videoBitRate = findViewById(R.id.videoBitRate);
         final MessageView videoFrameRate = findViewById(R.id.videoFrameRate);
 
@@ -69,6 +70,7 @@ public class VideoPreviewActivity extends AppCompatActivity {
         audio.setTitleAndMessage("Audio", result.getAudio().name());
         audioBitRate.setTitleAndMessage("Audio bit rate", result.getAudioBitRate() + " bits per sec.");
         videoCodec.setTitleAndMessage("VideoCodec", result.getVideoCodec().name());
+        audioCodec.setTitleAndMessage("AudioCodec", result.getAudioCodec().name());
         videoBitRate.setTitleAndMessage("Video bit rate", result.getVideoBitRate() + " bits per sec.");
         videoFrameRate.setTitleAndMessage("Video frame rate", result.getVideoFrameRate() + " fps");
         MediaController controller = new MediaController(this);

--- a/demo/src/main/res/layout/activity_video_preview.xml
+++ b/demo/src/main/res/layout/activity_video_preview.xml
@@ -40,6 +40,11 @@
             android:layout_height="wrap_content"/>
 
         <com.otaliastudios.cameraview.demo.MessageView
+            android:id="@+id/audioCodec"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <com.otaliastudios.cameraview.demo.MessageView
             android:id="@+id/videoCodec"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>

--- a/docs/_docs/controls.md
+++ b/docs/_docs/controls.md
@@ -70,6 +70,28 @@ cameraView.setVideoCodec(VideoCodec.H_263);
 cameraView.setVideoCodec(VideoCodec.H_264);
 ```
 
+##### cameraAudioCodec
+
+Sets the audio encoder for video recordings. Defaults to `DEVICE_DEFAULT`,
+which should typically be AAC.
+The available values are exposed through the `CameraOptions` object.
+
+`AudioCodec.VORBIS` is optionally supported on devices running Lolipop and above.
+`AudioCodec.HE_AAC` and `AudioCodec.AAC_ELD` require at least JellyBean.
+
+The library will safely fall back to device default if the min API requirements
+are not met.
+
+```java
+cameraView.setAudioCodec(AudioCodec.DEVICE_DEFAULT);
+cameraView.setAudioCodec(AudioCodec.AMR_NB);
+cameraView.setAudioCodec(AudioCodec.AMR_WB);
+cameraView.setAudioCodec(AudioCodec.AAC);
+cameraView.setAudioCodec(AudioCodec.HE_AAC);
+cameraView.setAudioCodec(AudioCodec.AAC_ELD);
+cameraView.setAudioCodec(AudioCodec.VORBIS);
+```
+
 ##### cameraWhiteBalance
 
 Sets the desired white balance for the current session.

--- a/docs/_docs/controls.md
+++ b/docs/_docs/controls.md
@@ -76,7 +76,6 @@ Sets the audio encoder for video recordings. Defaults to `DEVICE_DEFAULT`,
 which should typically be AAC.
 The available values are exposed through the `CameraOptions` object.
 
-`AudioCodec.VORBIS` is optionally supported on devices running Lolipop and above.
 `AudioCodec.HE_AAC` and `AudioCodec.AAC_ELD` require at least JellyBean.
 
 The library will safely fall back to device default if the min API requirements
@@ -84,12 +83,9 @@ are not met.
 
 ```java
 cameraView.setAudioCodec(AudioCodec.DEVICE_DEFAULT);
-cameraView.setAudioCodec(AudioCodec.AMR_NB);
-cameraView.setAudioCodec(AudioCodec.AMR_WB);
 cameraView.setAudioCodec(AudioCodec.AAC);
 cameraView.setAudioCodec(AudioCodec.HE_AAC);
 cameraView.setAudioCodec(AudioCodec.AAC_ELD);
-cameraView.setAudioCodec(AudioCodec.VORBIS);
 ```
 
 ##### cameraWhiteBalance


### PR DESCRIPTION
- Fixes ... (#860 )
- Tests: ... (yes)
- Docs updated: ... (yes)

### Solution
I followed the path of setting video codec as closely as I could. Adding `AudioCodec` as a control that can be set on `CameraView`. When `CameraBaseEngine#takeVideo` or `CameraBaseEngine#takeVideoSnapshot` are called, they set the codec on the `VideoResult.Stub` object. Later on in the flow, `FullVideoRecorder` will set any audio codec that isn't default on the `CamcorderProfile` object which is in turn used to set `audioType` and get the encoders.

One possible source of contention that I can see is the management of minimum sdk for some of the codecs. Open to ideas on this though.