### PR TITLE
Restart Camera1 Frame Processing After Taking a Picture - Fixes Issue 824

### DIFF
--- a/cameraview/src/androidTest/java/com/otaliastudios/cameraview/engine/CameraIntegrationTest.java
+++ b/cameraview/src/androidTest/java/com/otaliastudios/cameraview/engine/CameraIntegrationTest.java
@@ -1083,6 +1083,20 @@ public abstract class CameraIntegrationTest<E extends CameraBaseEngine> extends 
     @Test
     @Retry(emulatorOnly = true)
     @SdkExclude(maxSdkVersion = 22, emulatorOnly = true)
+    public void testFrameProcessing_afterPicture() throws Exception {
+        FrameProcessor processor = mock(FrameProcessor.class);
+        camera.addFrameProcessor(processor);
+        openSync(true);
+
+        camera.takePicture();
+        waitForPictureResult(true);
+
+        assert15Frames(processor);
+    }
+
+    @Test
+    @Retry(emulatorOnly = true)
+    @SdkExclude(maxSdkVersion = 22, emulatorOnly = true)
     public void testFrameProcessing_afterRestart() throws Exception {
         FrameProcessor processor = mock(FrameProcessor.class);
         camera.addFrameProcessor(processor);

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/picture/Full1PictureRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/picture/Full1PictureRecorder.java
@@ -2,12 +2,14 @@ package com.otaliastudios.cameraview.picture;
 
 import android.hardware.Camera;
 
-import com.otaliastudios.cameraview.PictureResult;
-import com.otaliastudios.cameraview.engine.Camera1Engine;
-import com.otaliastudios.cameraview.internal.ExifHelper;
-
 import androidx.annotation.NonNull;
 import androidx.exifinterface.media.ExifInterface;
+
+import com.otaliastudios.cameraview.PictureResult;
+import com.otaliastudios.cameraview.engine.Camera1Engine;
+import com.otaliastudios.cameraview.engine.offset.Reference;
+import com.otaliastudios.cameraview.internal.ExifHelper;
+import com.otaliastudios.cameraview.size.Size;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -40,6 +42,7 @@ public class Full1PictureRecorder extends FullPictureRecorder {
         // Stopping the preview callback is important on older APIs / emulators,
         // or takePicture can hang and leave the camera in a bad state.
         mCamera.setPreviewCallbackWithBuffer(null);
+        mEngine.getFrameManager().release();
         mCamera.takePicture(
                 new Camera.ShutterCallback() {
                     @Override
@@ -67,7 +70,21 @@ public class Full1PictureRecorder extends FullPictureRecorder {
                         mResult.data = data;
                         mResult.rotation = exifRotation;
                         LOG.i("take(): starting preview again. ", Thread.currentThread());
+
                         camera.setPreviewCallbackWithBuffer(mEngine);
+                        Size previewStreamSize = mEngine.getPreviewStreamSize(Reference.SENSOR);
+                        if (previewStreamSize == null) {
+                            throw new IllegalStateException("Preview stream size " +
+                                    "should never be null here.");
+                        }
+                        // Need to re-setup the frame manager, otherwise no frames are processed
+                        // after takePicture() is called
+                        mEngine.getFrameManager().setUp(
+                                mEngine.getFrameProcessingFormat(),
+                                previewStreamSize,
+                                mEngine.getAngles()
+                        );
+
                         camera.startPreview(); // This is needed, read somewhere in the docs.
                         dispatchResult();
                     }


### PR DESCRIPTION
- Fixes #824 
- Tests: No tests existed for the only edited class, `Full1PictureRecorder`
- Docs updated: No, fixes behind the scenes bug

### Solution
Took solution from @natario1 's comment on issue, simply needed to re-setup the frame manager after capturing a photo
