### PR TITLE
Add setter method for capture rate, can be used to record timelapse video

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -1576,6 +1576,26 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     }
 
     /**
+     * Sets the capture rate in frame per second for video capturing.
+     * it's can used to capture timelapse video
+     * Will be used by {@link #takeVideo(File)}.
+     *
+     * @param captureRate desired capture rate
+     */
+    public void setVideoCaptureRate(double captureRate) {
+        mCameraEngine.setVideoCaptureRate(captureRate);
+    }
+
+    /**
+     * Returns the current video bit rate.
+     * @return current bit rate
+     */
+    @SuppressWarnings("unused")
+    public double getVideoCaptureRate() {
+        return mCameraEngine.getVideoCaptureRate();
+    }
+
+    /**
      * A flag to control the behavior when calling {@link #setPreviewFrameRate(float)}.
      *
      * If the value is set to true, {@link #setPreviewFrameRate(float)} will choose the preview

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/VideoResult.java
@@ -41,6 +41,7 @@ public class VideoResult {
         public int maxDuration;
         public int endReason;
         public int videoBitRate;
+        public double videoCaptureRate;
         public int videoFrameRate;
         public int audioBitRate;
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -85,6 +85,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
     private long mVideoMaxSize;
     private int mVideoMaxDuration;
     private int mVideoBitRate;
+    private double mVideoCaptureRate;
     private int mAudioBitRate;
     private long mAutoFocusResetDelayMillis;
     private int mSnapshotMaxWidth; // in REF_VIEW like SizeSelectors
@@ -243,6 +244,16 @@ public abstract class CameraBaseEngine extends CameraEngine {
     @Override
     public final int getVideoBitRate() {
         return mVideoBitRate;
+    }
+
+    @Override
+    public final void setVideoCaptureRate(double videoCaptureRate) {
+        mVideoCaptureRate = videoCaptureRate;
+    }
+
+    @Override
+    public final double getVideoCaptureRate() {
+        return mVideoCaptureRate;
     }
 
     @Override
@@ -601,6 +612,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
                 stub.maxSize = mVideoMaxSize;
                 stub.maxDuration = mVideoMaxDuration;
                 stub.videoBitRate = mVideoBitRate;
+                stub.videoCaptureRate = mVideoCaptureRate;
                 stub.audioBitRate = mAudioBitRate;
                 onTakeVideo(stub);
             }
@@ -626,6 +638,7 @@ public abstract class CameraBaseEngine extends CameraEngine {
                 stub.location = mLocation;
                 stub.facing = mFacing;
                 stub.videoBitRate = mVideoBitRate;
+                stub.videoCaptureRate = mVideoCaptureRate;
                 stub.audioBitRate = mAudioBitRate;
                 stub.audio = mAudio;
                 stub.maxSize = mVideoMaxSize;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -635,6 +635,9 @@ public abstract class CameraEngine implements
     public abstract void setVideoBitRate(int videoBitRate);
     public abstract int getVideoBitRate();
 
+    public abstract void setVideoCaptureRate(double videoCaptureRate);
+    public abstract double getVideoCaptureRate();
+
     public abstract void setAudioBitRate(int audioBitRate);
     public abstract int getAudioBitRate();
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/FullVideoRecorder.java
@@ -215,6 +215,7 @@ public abstract class FullVideoRecorder extends VideoRecorder {
                 flip ? stub.size.getHeight() : stub.size.getWidth(),
                 flip ? stub.size.getWidth() : stub.size.getHeight());
         mMediaRecorder.setVideoFrameRate(stub.videoFrameRate);
+        mMediaRecorder.setCaptureRate(stub.videoCaptureRate);
         mMediaRecorder.setVideoEncoder(mProfile.videoCodec);
         mMediaRecorder.setVideoEncodingBitRate(stub.videoBitRate);
 


### PR DESCRIPTION
- Fixes ... 889
- Tests: ... No need
- Docs updated: ... no

### Solution
Added a new method to set the MediaRecorder capture rate, this will allow us to capture timelapse video.
