### PR TITLE
Fix for #927 OrientationHelper.enable() called twice

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -855,6 +855,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     public void close() {
         if (mInEditor) return;
+        mOrientationHelper.disable();
         mCameraEngine.stop(false);
         if (mCameraPreview != null) mCameraPreview.onPause();
     }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/internal/OrientationHelper.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/internal/OrientationHelper.java
@@ -38,7 +38,7 @@ public class OrientationHelper {
     final DisplayManager.DisplayListener mDisplayOffsetListener;
     private int mDisplayOffset = -1;
     
-    private boolean listenerEnabled;
+    private boolean mEnabled;
 
     /**
      * Creates a new orientation helper.
@@ -99,11 +99,11 @@ public class OrientationHelper {
      * Enables this listener.
      */
     public void enable() {
-        if(listenerEnabled) {
+        if (mEnabled) {
             //already enabled, will ignore call
             return;
         }
-        listenerEnabled = true;
+        mEnabled = true;
         mDisplayOffset = findDisplayOffset();
         if (Build.VERSION.SDK_INT >= 17) {
             DisplayManager manager = (DisplayManager)
@@ -117,7 +117,8 @@ public class OrientationHelper {
      * Disables this listener.
      */
     public void disable() {
-        listenerEnabled = false;
+        if (!mEnabled) return;
+        mEnabled = false;
         mDeviceOrientationListener.disable();
         if (Build.VERSION.SDK_INT >= 17) {
             DisplayManager manager = (DisplayManager)


### PR DESCRIPTION
- Fixes 927
- Tests: no
- Docs updated: no

### Solution
Added boolean to prevent listener activating multiple times.
Added a call in CameraView onPause to disable OrientationHelper 