### PR TITLE
[Bug] Camera is not being closed - Memory Leak

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -347,9 +347,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @NonNull
     protected CameraEngine instantiateCameraEngine(@NonNull Engine engine,
                                                    @NonNull CameraEngine.Callback callback) {
-        if (mExperimental
-                && engine == Engine.CAMERA2
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (mExperimental && engine == Engine.CAMERA2) {
             return new Camera2Engine(callback);
         } else {
             mEngine = Engine.CAMERA1;
@@ -2160,7 +2158,7 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         @NonNull
         @Override
         public Context getContext() {
-            return CameraView.this.getContext();
+            return CameraView.this.getContext().getApplicationContext();
         }
 
         @Override

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -347,7 +347,9 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @NonNull
     protected CameraEngine instantiateCameraEngine(@NonNull Engine engine,
                                                    @NonNull CameraEngine.Callback callback) {
-        if (mExperimental && engine == Engine.CAMERA2) {
+        if (mExperimental
+                && engine == Engine.CAMERA2
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             return new Camera2Engine(callback);
         } else {
             mEngine = Engine.CAMERA1;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -134,7 +134,8 @@ public abstract class CameraEngine implements
     private WorkerHandler mHandler;
     @VisibleForTesting Handler mCrashHandler;
     private final Callback mCallback;
-    private final CameraStateOrchestrator mOrchestrator = new CameraStateOrchestrator(new CameraOrchestrator.Callback() {
+    private final CameraStateOrchestrator mOrchestrator
+            = new CameraStateOrchestrator(new CameraOrchestrator.Callback() {
         @Override
         @NonNull
         public WorkerHandler getJobWorker(@NonNull String job) {

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/orchestrator/CameraOrchestrator.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/orchestrator/CameraOrchestrator.java
@@ -80,11 +80,13 @@ public class CameraOrchestrator {
     }
 
     public void release(){
-        mJobs.clear();
-        mDelayedJobs.clear();
+        synchronized (mLock){
+            mJobs.clear();
+            mDelayedJobs.clear();
 
-        reset();
-        mIsReleased = true;
+            reset();
+            mIsReleased = true;
+        }
     }
 
     public boolean isReleased(){

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/preview/CameraPreview.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/preview/CameraPreview.java
@@ -139,7 +139,6 @@ public abstract class CameraPreview<T extends View, Output> {
      * or a SurfaceTexture).
      * @return the surface object
      */
-    @NonNull
     public abstract Output getOutput();
 
     /**


### PR DESCRIPTION
### Issue
https://github.com/natario1/CameraView/issues/947

### Changes 

- Handle close camera device when the user leaves the screen before camera has been opened.
- Create Release function for Orchestrator to cancel all pending tasks.
- Handle NullPointerExceptions.
- Create function to force close camera.

### Solution

Make sure to close camera when the user leaves the screen before the camera is initialised. 
