### PR TITLE
Log errors when writing the image to a file

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraUtils.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraUtils.java
@@ -94,6 +94,7 @@ public class CameraUtils {
             stream.flush();
             return file;
         } catch (IOException e) {
+            LOG.e("writeToFile:", "could not write file.", e);
             return null;
         }
     }


### PR DESCRIPTION
One trivial line that would had saved me a couple of hours.

Writing the image to file may fail for reasons that are not always obvious.
In my case the directory did not always exist
Having a log with the cause can be really helpfull