### PR TITLE
Add custom camera engine support

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/controls/Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/controls/Engine.java
@@ -2,6 +2,7 @@ package com.otaliastudios.cameraview.controls;
 
 
 import com.otaliastudios.cameraview.CameraView;
+import com.otaliastudios.cameraview.engine.CustomCameraEngine;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,7 +23,13 @@ public enum Engine implements Control {
      * Camera2 based engine. For API versions older than 21,
      * the system falls back to {@link #CAMERA1}.
      */
-    CAMERA2(1);
+    CAMERA2(1),
+
+    /**
+     * Custom camera engine implemented by the app.
+     * See {@link CameraView#setCustomEngine(CustomCameraEngine)}.
+     */
+    CUSTOM(2);
 
     final static Engine DEFAULT = CAMERA1;
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CallbackProxy.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CallbackProxy.java
@@ -1,0 +1,98 @@
+package com.otaliastudios.cameraview.engine;
+
+import android.content.Context;
+import android.graphics.PointF;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.otaliastudios.cameraview.CameraException;
+import com.otaliastudios.cameraview.CameraOptions;
+import com.otaliastudios.cameraview.PictureResult;
+import com.otaliastudios.cameraview.VideoResult;
+import com.otaliastudios.cameraview.frame.Frame;
+import com.otaliastudios.cameraview.gesture.Gesture;
+
+public class CallbackProxy implements CameraEngine.Callback {
+    private CameraEngine.Callback mCallbacks;
+
+    public void setCallbacks(CameraEngine.Callback callbacks) {
+        mCallbacks = callbacks;
+    }
+
+    @NonNull
+    @Override
+    public Context getContext() {
+        return mCallbacks.getContext();
+    }
+
+    @Override
+    public void dispatchOnCameraOpened(@NonNull CameraOptions options) {
+        mCallbacks.dispatchOnCameraOpened(options);
+    }
+
+    @Override
+    public void dispatchOnCameraClosed() {
+        mCallbacks.dispatchOnCameraClosed();
+    }
+
+    @Override
+    public void onCameraPreviewStreamSizeChanged() {
+        mCallbacks.onCameraPreviewStreamSizeChanged();
+    }
+
+    @Override
+    public void dispatchOnPictureShutter(boolean shouldPlaySound) {
+        mCallbacks.dispatchOnPictureShutter(shouldPlaySound);
+    }
+
+    @Override
+    public void dispatchOnVideoTaken(@NonNull VideoResult.Stub stub) {
+        mCallbacks.dispatchOnVideoTaken(stub);
+    }
+
+    @Override
+    public void dispatchOnPictureTaken(@NonNull PictureResult.Stub stub) {
+        mCallbacks.dispatchOnPictureTaken(stub);
+    }
+
+    @Override
+    public void dispatchOnFocusStart(@Nullable Gesture trigger, @NonNull PointF where) {
+        mCallbacks.dispatchOnFocusStart(trigger, where);
+    }
+
+    @Override
+    public void dispatchOnFocusEnd(@Nullable Gesture trigger, boolean success, @NonNull PointF where) {
+        mCallbacks.dispatchOnFocusEnd(trigger, success, where);
+    }
+
+    @Override
+    public void dispatchOnZoomChanged(float newValue, @Nullable PointF[] fingers) {
+        mCallbacks.dispatchOnZoomChanged(newValue, fingers);
+    }
+
+    @Override
+    public void dispatchOnExposureCorrectionChanged(float newValue, @NonNull float[] bounds, @Nullable PointF[] fingers) {
+        mCallbacks.dispatchOnExposureCorrectionChanged(newValue, bounds, fingers);
+    }
+
+    @Override
+    public void dispatchFrame(@NonNull Frame frame) {
+        mCallbacks.dispatchFrame(frame);
+    }
+
+    @Override
+    public void dispatchError(CameraException exception) {
+        mCallbacks.dispatchError(exception);
+    }
+
+    @Override
+    public void dispatchOnVideoRecordingStart() {
+        mCallbacks.dispatchOnVideoRecordingStart();
+    }
+
+    @Override
+    public void dispatchOnVideoRecordingEnd() {
+        mCallbacks.dispatchOnVideoRecordingEnd();
+    }
+}

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CustomCameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CustomCameraEngine.java
@@ -1,0 +1,11 @@
+package com.otaliastudios.cameraview.engine;
+
+public abstract class CustomCameraEngine extends CameraBaseEngine {
+    protected CustomCameraEngine() {
+        super(new CallbackProxy());
+    }
+
+    public void setCallbacks(Callback callbacks) {
+        ((CallbackProxy) getCallback()).setCallbacks(callbacks);
+    }
+}


### PR DESCRIPTION
### Before you go
https://github.com/natario1/CameraView/issues/1069

### Solution
Added an API:

- `setCustomEngine(@NonNull CustomCameraEngine engine)`

Since callbacks are owned by `CameraView`, are inaccessible via public APIs, and are required to instantiate `CameraBaseEngine`, the `CallbackProxy` class was added to allow the callbacks to be set by `CameraView` when switching to the custom engine, but without requiring the app to have access to them when instantiating the engine.
