### PR TITLE
#1088: add Pixel 4XL into FpsRangeValidator

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/internal/FpsRangeValidator.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/internal/FpsRangeValidator.java
@@ -24,6 +24,7 @@ public class FpsRangeValidator {
     static {
         sIssues.put("Google Pixel 4", Arrays.asList(new Range<>(15, 60)));
         sIssues.put("Google Pixel 4a", Arrays.asList(new Range<>(15, 60)));
+        sIssues.put("Google Pixel 4 XL", Arrays.asList(new Range<>(15, 60)));
     }
 
     public static boolean validate(Range<Integer> range) {


### PR DESCRIPTION
### Before you go
Unless this is a simple fix (typos, bugs with obvious solution), please open an issue first so that
we can discuss the best approach to address the problem. Without a reference issue and discussion, 
unfortunately, this PR will likely be ignored.

If the edited files were covered by tests, updated tests are required for merging. 
Please look into the tests folders and make sure you cover new code.

- Fixes ... (*issue number*)
- Tests: ... (*yes/no*)
- Docs updated: ... (*yes/no*)

### Solution
'Pixel 4XL' added to list of problematic devices in FpsRangeValidator
