### PR TITLE
Fix the setSize typo in SnapshotVideoRecorder

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -245,7 +245,7 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
 
             // Adjustment
             mResult.rotation = 0; // We will rotate the result instead.
-            mCurrentFilter.setSize(mResult.size.getWidth(), mResult.size.getWidth());
+            mCurrentFilter.setSize(mResult.size.getWidth(), mResult.size.getHeight());
 
             // Audio
             AudioMediaEncoder audioEncoder = null;


### PR DESCRIPTION
Hi, @natario1. `setSize` requires a width and a height, but the line passes two widths. Usually, this wouldn't cause a problem, but the video size would be wrong when taking a snapshot video with a MultiFilter.

Issue #837 mentioned something similar.
