### PR TITLE
Saves file from takeVideoSnapshot function to gallery on Android API 29+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.3")
+        classpath("com.android.tools.build:gradle:7.3.1")
         classpath("io.deepmedia.tools:publisher:0.6.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
 

--- a/cameraview/build.gradle.kts
+++ b/cameraview/build.gradle.kts
@@ -19,6 +19,7 @@ android {
                 "com.otaliastudios.cameraview.tools.SdkExcludeFilter," +
                 "com.otaliastudios.cameraview.tools.SdkIncludeFilter"
     }
+    namespace = "com.otaliastudios.cameraview"
     buildTypes["debug"].isTestCoverageEnabled = true
     buildTypes["release"].isMinifyEnabled = false
 }

--- a/cameraview/src/androidTest/AndroidManifest.xml
+++ b/cameraview/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.otaliastudios.cameraview">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/cameraview/src/main/AndroidManifest.xml
+++ b/cameraview/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.otaliastudios.cameraview">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA" />
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraBaseEngine.java
@@ -352,15 +352,15 @@ public abstract class CameraBaseEngine extends CameraEngine {
             mFacing = facing;
             getOrchestrator().scheduleStateful("facing", CameraState.ENGINE,
                     new Runnable() {
-                @Override
-                public void run() {
-                    if (collectCameraInfo(facing)) {
-                        restart();
-                    } else {
-                        mFacing = old;
-                    }
-                }
-            });
+                        @Override
+                        public void run() {
+                            if (collectCameraInfo(facing)) {
+                                restart();
+                            } else {
+                                mFacing = old;
+                            }
+                        }
+                    });
         }
     }
 
@@ -401,11 +401,11 @@ public abstract class CameraBaseEngine extends CameraEngine {
             mMode = mode;
             getOrchestrator().scheduleStateful("mode", CameraState.ENGINE,
                     new Runnable() {
-                @Override
-                public void run() {
-                    restart();
-                }
-            });
+                        @Override
+                        public void run() {
+                            restart();
+                        }
+                    });
         }
     }
 
@@ -508,20 +508,20 @@ public abstract class CameraBaseEngine extends CameraEngine {
         final boolean metering = mPictureMetering;
         getOrchestrator().scheduleStateful("take picture", CameraState.BIND,
                 new Runnable() {
-            @Override
-            public void run() {
-                LOG.i("takePicture:", "running. isTakingPicture:", isTakingPicture());
-                if (isTakingPicture()) return;
-                if (mMode == Mode.VIDEO) {
-                    throw new IllegalStateException("Can't take hq pictures while in VIDEO mode");
-                }
-                stub.isSnapshot = false;
-                stub.location = mLocation;
-                stub.facing = mFacing;
-                stub.format = mPictureFormat;
-                onTakePicture(stub, metering);
-            }
-        });
+                    @Override
+                    public void run() {
+                        LOG.i("takePicture:", "running. isTakingPicture:", isTakingPicture());
+                        if (isTakingPicture()) return;
+                        if (mMode == Mode.VIDEO) {
+                            throw new IllegalStateException("Can't take hq pictures while in VIDEO mode");
+                        }
+                        stub.isSnapshot = false;
+                        stub.location = mLocation;
+                        stub.facing = mFacing;
+                        stub.format = mPictureFormat;
+                        onTakePicture(stub, metering);
+                    }
+                });
     }
 
     /**
@@ -535,20 +535,20 @@ public abstract class CameraBaseEngine extends CameraEngine {
         final boolean metering = mPictureSnapshotMetering;
         getOrchestrator().scheduleStateful("take picture snapshot", CameraState.BIND,
                 new Runnable() {
-            @Override
-            public void run() {
-                LOG.i("takePictureSnapshot:", "running. isTakingPicture:", isTakingPicture());
-                if (isTakingPicture()) return;
-                stub.location = mLocation;
-                stub.isSnapshot = true;
-                stub.facing = mFacing;
-                stub.format = PictureFormat.JPEG;
-                // Leave the other parameters to subclasses.
-                //noinspection ConstantConditions
-                AspectRatio ratio = AspectRatio.of(getPreviewSurfaceSize(Reference.OUTPUT));
-                onTakePictureSnapshot(stub, ratio, metering);
-            }
-        });
+                    @Override
+                    public void run() {
+                        LOG.i("takePictureSnapshot:", "running. isTakingPicture:", isTakingPicture());
+                        if (isTakingPicture()) return;
+                        stub.location = mLocation;
+                        stub.isSnapshot = true;
+                        stub.facing = mFacing;
+                        stub.format = PictureFormat.JPEG;
+                        // Leave the other parameters to subclasses.
+                        //noinspection ConstantConditions
+                        AspectRatio ratio = AspectRatio.of(getPreviewSurfaceSize(Reference.OUTPUT));
+                        onTakePictureSnapshot(stub, ratio, metering);
+                    }
+                });
     }
 
     @Override
@@ -612,29 +612,36 @@ public abstract class CameraBaseEngine extends CameraEngine {
      * @param file the output file
      */
     @Override
-    public final void takeVideoSnapshot(@NonNull final VideoResult.Stub stub,
-                                        @NonNull final File file) {
+    public final void takeVideoSnapshot(final @NonNull VideoResult.Stub stub,
+                                        final @Nullable File file,
+                                        final @Nullable FileDescriptor fileDescriptor) {
         getOrchestrator().scheduleStateful("take video snapshot", CameraState.BIND,
                 new Runnable() {
-            @Override
-            public void run() {
-                LOG.i("takeVideoSnapshot:", "running. isTakingVideo:", isTakingVideo());
-                stub.file = file;
-                stub.isSnapshot = true;
-                stub.videoCodec = mVideoCodec;
-                stub.audioCodec = mAudioCodec;
-                stub.location = mLocation;
-                stub.facing = mFacing;
-                stub.videoBitRate = mVideoBitRate;
-                stub.audioBitRate = mAudioBitRate;
-                stub.audio = mAudio;
-                stub.maxSize = mVideoMaxSize;
-                stub.maxDuration = mVideoMaxDuration;
-                //noinspection ConstantConditions
-                AspectRatio ratio = AspectRatio.of(getPreviewSurfaceSize(Reference.OUTPUT));
-                onTakeVideoSnapshot(stub, ratio);
-            }
-        });
+                    @Override
+                    public void run() {
+                        LOG.i("takeVideoSnapshot:", "running. isTakingVideo:", isTakingVideo());
+                        if (file != null) {
+                            stub.file = file;
+                        } else if (fileDescriptor != null) {
+                            stub.fileDescriptor = fileDescriptor;
+                        } else {
+                            throw new IllegalStateException("file and fileDescriptor are both null.");
+                        }
+                        stub.isSnapshot = true;
+                        stub.videoCodec = mVideoCodec;
+                        stub.audioCodec = mAudioCodec;
+                        stub.location = mLocation;
+                        stub.facing = mFacing;
+                        stub.videoBitRate = mVideoBitRate;
+                        stub.audioBitRate = mAudioBitRate;
+                        stub.audio = mAudio;
+                        stub.maxSize = mVideoMaxSize;
+                        stub.maxDuration = mVideoMaxDuration;
+                        //noinspection ConstantConditions
+                        AspectRatio ratio = AspectRatio.of(getPreviewSurfaceSize(Reference.OUTPUT));
+                        onTakeVideoSnapshot(stub, ratio);
+                    }
+                });
     }
 
     @Override
@@ -706,21 +713,21 @@ public abstract class CameraBaseEngine extends CameraEngine {
         LOG.i("onSurfaceChanged:", "Size is", getPreviewSurfaceSize(Reference.VIEW));
         getOrchestrator().scheduleStateful("surface changed", CameraState.BIND,
                 new Runnable() {
-            @Override
-            public void run() {
-                // Compute a new camera preview size and apply.
-                Size newSize = computePreviewStreamSize();
-                if (newSize.equals(mPreviewStreamSize)) {
-                    LOG.i("onSurfaceChanged:",
-                            "The computed preview size is identical. No op.");
-                } else {
-                    LOG.i("onSurfaceChanged:",
-                            "Computed a new preview size. Calling onPreviewStreamSizeChanged().");
-                    mPreviewStreamSize = newSize;
-                    onPreviewStreamSizeChanged();
-                }
-            }
-        });
+                    @Override
+                    public void run() {
+                        // Compute a new camera preview size and apply.
+                        Size newSize = computePreviewStreamSize();
+                        if (newSize.equals(mPreviewStreamSize)) {
+                            LOG.i("onSurfaceChanged:",
+                                    "The computed preview size is identical. No op.");
+                        } else {
+                            LOG.i("onSurfaceChanged:",
+                                    "Computed a new preview size. Calling onPreviewStreamSizeChanged().");
+                            mPreviewStreamSize = newSize;
+                            onPreviewStreamSizeChanged();
+                        }
+                    }
+                });
     }
 
     /**

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/CameraEngine.java
@@ -382,15 +382,15 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.OFF, CameraState.ENGINE,
                 true,
                 new Callable<Task<CameraOptions>>() {
-            @Override
-            public Task<CameraOptions> call() {
-                if (!collectCameraInfo(getFacing())) {
-                    LOG.e("onStartEngine:", "No camera available for facing", getFacing());
-                    throw new CameraException(CameraException.REASON_NO_CAMERA);
-                }
-                return onStartEngine();
-            }
-        }).onSuccessTask(new SuccessContinuation<CameraOptions, Void>() {
+                    @Override
+                    public Task<CameraOptions> call() {
+                        if (!collectCameraInfo(getFacing())) {
+                            LOG.e("onStartEngine:", "No camera available for facing", getFacing());
+                            throw new CameraException(CameraException.REASON_NO_CAMERA);
+                        }
+                        return onStartEngine();
+                    }
+                }).onSuccessTask(new SuccessContinuation<CameraOptions, Void>() {
             @NonNull
             @Override
             public Task<Void> then(@Nullable CameraOptions cameraOptions) {
@@ -409,11 +409,11 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.ENGINE, CameraState.OFF,
                 !swallowExceptions,
                 new Callable<Task<Void>>() {
-            @Override
-            public Task<Void> call() {
-                return onStopEngine();
-            }
-        }).addOnSuccessListener(new OnSuccessListener<Void>() {
+                    @Override
+                    public Task<Void> call() {
+                        return onStopEngine();
+                    }
+                }).addOnSuccessListener(new OnSuccessListener<Void>() {
             @Override
             public void onSuccess(Void aVoid) {
                 // Put this on the outer task so we're sure it's called after getState() is OFF.
@@ -464,15 +464,15 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.ENGINE, CameraState.BIND,
                 true,
                 new Callable<Task<Void>>() {
-            @Override
-            public Task<Void> call() {
-                if (getPreview() != null && getPreview().hasSurface()) {
-                    return onStartBind();
-                } else {
-                    return Tasks.forCanceled();
-                }
-            }
-        });
+                    @Override
+                    public Task<Void> call() {
+                        if (getPreview() != null && getPreview().hasSurface()) {
+                            return onStartBind();
+                        } else {
+                            return Tasks.forCanceled();
+                        }
+                    }
+                });
     }
 
     @SuppressWarnings("UnusedReturnValue")
@@ -482,11 +482,11 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.BIND, CameraState.ENGINE,
                 !swallowExceptions,
                 new Callable<Task<Void>>() {
-            @Override
-            public Task<Void> call() {
-                return onStopBind();
-            }
-        });
+                    @Override
+                    public Task<Void> call() {
+                        return onStopBind();
+                    }
+                });
     }
 
     /**
@@ -517,11 +517,11 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.BIND, CameraState.PREVIEW,
                 true,
                 new Callable<Task<Void>>() {
-            @Override
-            public Task<Void> call() {
-                return onStartPreview();
-            }
-        });
+                    @Override
+                    public Task<Void> call() {
+                        return onStartPreview();
+                    }
+                });
     }
 
     @SuppressWarnings("UnusedReturnValue")
@@ -531,11 +531,11 @@ public abstract class CameraEngine implements
         return mOrchestrator.scheduleStateChange(CameraState.PREVIEW, CameraState.BIND,
                 !swallowExceptions,
                 new Callable<Task<Void>>() {
-            @Override
-            public Task<Void> call() {
-                return onStopPreview();
-            }
-        });
+                    @Override
+                    public Task<Void> call() {
+                        return onStopPreview();
+                    }
+                });
     }
 
     /**
@@ -721,7 +721,10 @@ public abstract class CameraEngine implements
     public abstract void takeVideo(@NonNull VideoResult.Stub stub,
                                    @Nullable File file,
                                    @Nullable FileDescriptor fileDescriptor);
-    public abstract void takeVideoSnapshot(@NonNull VideoResult.Stub stub, @NonNull File file);
+    // FileDescriptor options for Android 10+
+    public abstract void takeVideoSnapshot(@NonNull VideoResult.Stub stub,
+                                           @Nullable File file,
+                                           @Nullable FileDescriptor fileDescriptor);
     public abstract void stopVideo();
 
     //endregion

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/SnapshotVideoRecorder.java
@@ -258,12 +258,21 @@ public class SnapshotVideoRecorder extends VideoRecorder implements RendererFram
 
             // Engine
             synchronized (mEncoderEngineLock) {
-                mEncoderEngine = new MediaEncoderEngine(mResult.file,
-                        videoEncoder,
-                        audioEncoder,
-                        mResult.maxDuration,
-                        mResult.maxSize,
-                        SnapshotVideoRecorder.this);
+                if (mResult.file != null) {
+                    mEncoderEngine = new MediaEncoderEngine(mResult.file,
+                            videoEncoder,
+                            audioEncoder,
+                            mResult.maxDuration,
+                            mResult.maxSize,
+                            SnapshotVideoRecorder.this);
+                }else{
+                    mEncoderEngine = new MediaEncoderEngine(mResult.fileDescriptor,
+                            videoEncoder,
+                            audioEncoder,
+                            mResult.maxDuration,
+                            mResult.maxSize,
+                            SnapshotVideoRecorder.this);
+                }
                 mEncoderEngine.notify(TextureMediaEncoder.FILTER_EVENT, mCurrentFilter);
                 mEncoderEngine.start();
             }

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -14,6 +14,7 @@ android {
         vectorDrawables.useSupportLibrary = true
     }
     sourceSets["main"].java.srcDir("src/main/kotlin")
+    namespace = "com.otaliastudios.cameraview.demo"
 }
 
 dependencies {

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.otaliastudios.cameraview.demo">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
 

--- a/demo/src/main/kotlin/com/otaliastudios/cameraview/demo/VideoPreviewActivity.kt
+++ b/demo/src/main/kotlin/com/otaliastudios/cameraview/demo/VideoPreviewActivity.kt
@@ -2,6 +2,7 @@ package com.otaliastudios.cameraview.demo
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
@@ -17,6 +18,7 @@ import com.otaliastudios.cameraview.size.AspectRatio
 class VideoPreviewActivity : AppCompatActivity() {
     companion object {
         var videoResult: VideoResult? = null
+        var fdUri:Uri?=null
     }
 
     private val videoView: VideoView by lazy { findViewById<VideoView>(R.id.video) }
@@ -54,7 +56,12 @@ class VideoPreviewActivity : AppCompatActivity() {
         controller.setAnchorView(videoView)
         controller.setMediaPlayer(videoView)
         videoView.setMediaController(controller)
-        videoView.setVideoURI(Uri.fromFile(result.file))
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+
+            videoView.setVideoURI(fdUri)
+        }else{
+            videoView.setVideoURI(Uri.fromFile(result.file))
+        }
         videoView.setOnPreparedListener { mp ->
             val lp = videoView.layoutParams
             val videoWidth = mp.videoWidth.toFloat()
@@ -94,8 +101,8 @@ class VideoPreviewActivity : AppCompatActivity() {
             val intent = Intent(Intent.ACTION_SEND)
             intent.type = "video/*"
             val uri = FileProvider.getUriForFile(this,
-                    this.packageName + ".provider",
-                    videoResult!!.file)
+                this.packageName + ".provider",
+                videoResult!!.file)
             intent.putExtra(Intent.EXTRA_STREAM, uri)
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             startActivity(intent)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
### Before you go
- Fixes: ... (*#799*)
- Tests: ... (*yes*)
- Docs updated: ... (*yes*)

### Solution
I added the option to save a video using a FileDescriptor on Android 29+. This can be tested using the `SNAP` button on the camera preview.
