### PR TITLE
Update OverlayDrawer.java

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/overlay/OverlayDrawer.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/overlay/OverlayDrawer.java
@@ -78,7 +78,11 @@ public class OverlayDrawer {
         }
         synchronized (mIssue514WorkaroundLock) {
             mIssue514Workaround.beforeOverlayUpdateTexImage();
-            mSurfaceTexture.updateTexImage();
+            try {
+                mSurfaceTexture.updateTexImage();
+            } catch (IllegalStateException e) {
+                LOG.w("Got IllegalStateException while updating texture contents", e);
+            }
         }
         mSurfaceTexture.getTransformMatrix(mTextureDrawer.getTextureTransform());
     }


### PR DESCRIPTION
Simple try/catch prevents app from crashing in this recoverable error.