### PR TITLE
try/catch getCameraInfo() on Camera1Engine.java

### DIFF
--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraListener.java
@@ -169,5 +169,21 @@ public abstract class CameraListener {
     public void onPictureShutter() {
 
     }
+
+    /**
+     * Notifies that a finger gesture just triggered a swipe left event.
+     * This can be used to exchange between different filters or to
+     * swap between front and back cameras.
+     */
+    @UiThread
+    public void onSwipeLeft() {}
+
+    /**
+     * Notifies that a finger gesture just triggered a swipe right event.
+     * This can be used to exchange between different filters or to
+     * swap between front and back cameras.
+     */
+    @UiThread
+    public void onSwipeRight() {}
     
 }

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -669,32 +669,34 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
             onGesture(mTapGestureFinder, options);
         }
 
-        if(event.getAction() == MotionEvent.ACTION_DOWN) x1 = event.getX();
-        if(event.getAction() == MotionEvent.ACTION_UP) {
-            x2 = event.getX();
-            float deltaX = x2 - x1;
-            if(deltaX > MIN_SWIPE_DISTANCE) {
-                mUiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        for (CameraListener listener : mListeners) {
-                            listener.onSwipeRight();
+        // Only detect swipes for single-finger gestures
+        if(event.getPointerCount() == 1) {
+            if(event.getAction() == MotionEvent.ACTION_DOWN) x1 = event.getX();
+            if(event.getAction() == MotionEvent.ACTION_UP) {
+                x2 = event.getX();
+                float deltaX = x2 - x1;
+                if(deltaX > MIN_SWIPE_DISTANCE) {
+                    mUiHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            for (CameraListener listener : mListeners) {
+                                listener.onSwipeRight();
+                            }
                         }
-                    }
-                });
-            }
-            if (deltaX < MIN_SWIPE_DISTANCE) {
-                mUiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        for (CameraListener listener : mListeners) {
-                            listener.onSwipeLeft();
+                    });
+                }
+                if (deltaX < -MIN_SWIPE_DISTANCE) {
+                    mUiHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            for (CameraListener listener : mListeners) {
+                                listener.onSwipeLeft();
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }
         }
-
         return true;
     }
 

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -658,9 +658,12 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         // Pass to our own GestureLayouts
         CameraOptions options = mCameraEngine.getCameraOptions(); // Non null
         if (options == null) throw new IllegalStateException("Options should not be null here.");
+
+        boolean ongoingPinchEvent = false;
         if (mPinchGestureFinder.onTouchEvent(event)) {
             LOG.i("onTouchEvent", "pinch!");
             onGesture(mPinchGestureFinder, options);
+            ongoingPinchEvent = true;
         } else if (mScrollGestureFinder.onTouchEvent(event)) {
             LOG.i("onTouchEvent", "scroll!");
             onGesture(mScrollGestureFinder, options);
@@ -669,8 +672,8 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
             onGesture(mTapGestureFinder, options);
         }
 
-        // Only detect swipes for single-finger gestures
-        if(event.getPointerCount() == 1) {
+        // Only detect swipes for single-finger gestures that haven't been handled by pinch gesture finder
+        if(!ongoingPinchEvent && event.getPointerCount() == 1) {
             if(event.getAction() == MotionEvent.ACTION_DOWN) x1 = event.getX();
             if(event.getAction() == MotionEvent.ACTION_UP) {
                 x2 = event.getX();

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/CameraView.java
@@ -154,6 +154,9 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
     @VisibleForTesting TapGestureFinder mTapGestureFinder;
     @VisibleForTesting ScrollGestureFinder mScrollGestureFinder;
 
+    private float x1,x2;
+    static final int MIN_SWIPE_DISTANCE = 150;
+    
     // Views
     @VisibleForTesting GridLinesLayout mGridLinesLayout;
     @VisibleForTesting MarkerLayout mMarkerLayout;
@@ -664,6 +667,32 @@ public class CameraView extends FrameLayout implements LifecycleObserver {
         } else if (mTapGestureFinder.onTouchEvent(event)) {
             LOG.i("onTouchEvent", "tap!");
             onGesture(mTapGestureFinder, options);
+        }
+
+        if(event.getAction() == MotionEvent.ACTION_DOWN) x1 = event.getX();
+        if(event.getAction() == MotionEvent.ACTION_UP) {
+            x2 = event.getX();
+            float deltaX = x2 - x1;
+            if(deltaX > MIN_SWIPE_DISTANCE) {
+                mUiHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (CameraListener listener : mListeners) {
+                            listener.onSwipeRight();
+                        }
+                    }
+                });
+            }
+            if (deltaX < MIN_SWIPE_DISTANCE) {
+                mUiHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (CameraListener listener : mListeners) {
+                            listener.onSwipeLeft();
+                        }
+                    }
+                });
+            }
         }
 
         return true;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
@@ -141,7 +141,11 @@ public class Camera1Engine extends CameraBaseEngine implements
                 "Cameras:", Camera.getNumberOfCameras());
         Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
         for (int i = 0, count = Camera.getNumberOfCameras(); i < count; i++) {
-            Camera.getCameraInfo(i, cameraInfo);
+            try {
+                Camera.getCameraInfo(i, cameraInfo);    
+            } catch (RuntimeException e) {
+                return false;
+            }
             if (cameraInfo.facing == internalFacing) {
                 getAngles().setSensorOffset(facing, cameraInfo.orientation);
                 mCameraId = i;

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
@@ -528,8 +528,14 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyFlash(params, old)) mCamera.setParameters(params);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyFlash(params, old)) mCamera.setParameters(params);
+                } catch (RuntimeException e) {
+                    LOG.e("onSetFlash:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
+                }
             }
         });
     }
@@ -552,8 +558,14 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyLocation(params, oldLocation)) mCamera.setParameters(params);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyLocation(params, oldLocation)) mCamera.setParameters(params);
+                } catch (RuntimeException e) {
+                    LOG.e("onSetLocation:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
+                }
             }
         });
     }
@@ -580,8 +592,14 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyWhiteBalance(params, old)) mCamera.setParameters(params);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyWhiteBalance(params, old)) mCamera.setParameters(params);
+                } catch (RuntimeException e) {
+                    LOG.e("onSetWhiteBalance:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
+                }
             }
         });
     }
@@ -609,8 +627,14 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyHdr(params, old)) mCamera.setParameters(params);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyHdr(params, old)) mCamera.setParameters(params);
+                } catch (RuntimeException e) {
+                    LOG.e("onSetHdr:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
+                }
             }
         });
     }
@@ -635,12 +659,18 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyZoom(params, old)) {
-                    mCamera.setParameters(params);
-                    if (notify) {
-                        getCallback().dispatchOnZoomChanged(mZoomValue, points);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyZoom(params, old)) {
+                        mCamera.setParameters(params);
+                        if (notify) {
+                            getCallback().dispatchOnZoomChanged(mZoomValue, points);
+                        }
                     }
+                } catch (RuntimeException e) {
+                    LOG.e("onSetZoom:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
                 }
             }
         });
@@ -670,13 +700,19 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyExposureCorrection(params, old)) {
-                    mCamera.setParameters(params);
-                    if (notify) {
-                        getCallback().dispatchOnExposureCorrectionChanged(mExposureCorrectionValue,
-                                bounds, points);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyExposureCorrection(params, old)) {
+                        mCamera.setParameters(params);
+                        if (notify) {
+                            getCallback().dispatchOnExposureCorrectionChanged(mExposureCorrectionValue,
+                                    bounds, points);
+                        }
                     }
+                } catch (RuntimeException e) {
+                    LOG.e("onSetExposureCorrection:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
                 }
             }
         });
@@ -748,8 +784,14 @@ public class Camera1Engine extends CameraBaseEngine implements
                 new Runnable() {
             @Override
             public void run() {
-                Camera.Parameters params = mCamera.getParameters();
-                if (applyPreviewFrameRate(params, old)) mCamera.setParameters(params);
+                try {
+                    Camera.Parameters params = mCamera.getParameters();
+                    if (applyPreviewFrameRate(params, old)) mCamera.setParameters(params);
+                } catch (RuntimeException e) {
+                    LOG.e("onSetPreviewFrameRate:", "Failed to get params from camera. Maybe low level problem with camera or camera has already released?");
+                    //Should throw exception? Looks inappropriate at this point if camera is working...
+                    //throw new CameraException(e, CameraException.REASON_FAILED_TO_START_PREVIEW);
+                }
             }
         });
     }
@@ -879,7 +921,13 @@ public class Camera1Engine extends CameraBaseEngine implements
                         getPreview().getSurfaceSize());
                 MeteringRegions transformed = regions.transform(transform);
 
-                Camera.Parameters params = mCamera.getParameters();
+                Camera.Parameters params;
+                try {
+                    params = mCamera.getParameters();
+                } catch (RuntimeException re) {
+                    LOG.e("startAutoFocus:", "Failed to get camera parameters");
+                    throw new CameraException(re, CameraException.REASON_UNKNOWN);
+                }
                 int maxAF = params.getMaxNumFocusAreas();
                 int maxAE = params.getMaxNumMeteringAreas();
                 if (maxAF > 0) params.setFocusAreas(transformed.get(maxAF, transform));

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/engine/Camera1Engine.java
@@ -144,7 +144,7 @@ public class Camera1Engine extends CameraBaseEngine implements
             try {
                 Camera.getCameraInfo(i, cameraInfo);    
             } catch (RuntimeException e) {
-                return false;
+                continue;
             }
             if (cameraInfo.facing == internalFacing) {
                 getAngles().setSensorOffset(facing, cameraInfo.orientation);

--- a/cameraview/src/main/java/com/otaliastudios/cameraview/video/encoding/VideoMediaEncoder.java
+++ b/cameraview/src/main/java/com/otaliastudios/cameraview/video/encoding/VideoMediaEncoder.java
@@ -81,7 +81,11 @@ abstract class VideoMediaEncoder<C extends VideoConfig> extends MediaEncoder {
         }
         mMediaCodec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
         mSurface = mMediaCodec.createInputSurface();
-        mMediaCodec.start();
+        try {
+            mMediaCodec.start();
+        } catch (MediaCodec.CodecException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @EncoderThread


### PR DESCRIPTION
Please merge, this is a small try/catch that helps to prevent the apps using the library from crashing on devices using the old Camera1 API.

Fix Runtime Exception on devices trying to use Camera1

Fatal Exception: java.lang.RuntimeException: Fail to get camera info
       at android.hardware.Camera.getCameraInfo(Camera.java:332)
       at com.otaliastudios.cameraview.engine.Camera1Engine.collectCameraInfo(Camera1Engine.java:144)


